### PR TITLE
Link modifiers now have site dependence

### DIFF
--- a/src/Engine/ManyToTwoConnection.h
+++ b/src/Engine/ManyToTwoConnection.h
@@ -1,6 +1,7 @@
 #ifndef MANYTOTWOCONNECTION_H
 #define MANYTOTWOCONNECTION_H
 #include "MetaOpForConnection.hh"
+#include "OneLink.hh"
 #include "ProgramGlobals.h"
 
 namespace Dmrg
@@ -16,7 +17,8 @@ public:
 
 	typedef std::pair<SizeType, SizeType> PairSizeType;
 	typedef PsimagLite::Vector<SizeType>::Type VectorSizeType;
-	typedef typename ModelLinksType::TermType::OneLinkType ModelTermLinkType;
+	using ComplexOrRealType = typename ModelLinksType::ComplexOrRealType;
+	using ModelTermLinkType = OneLink<ComplexOrRealType>;
 	typedef typename ModelLinksType::HermitianEnum HermitianEnum;
 	using PairMetaOpForConnection = std::pair<MetaOpForConnection, MetaOpForConnection>;
 

--- a/src/Engine/OneLink.hh
+++ b/src/Engine/OneLink.hh
@@ -1,0 +1,68 @@
+#ifndef ONELINK_HH
+#define ONELINK_HH
+#include "ProgramGlobals.h"
+#include <functional>
+
+namespace Dmrg
+{
+
+template <typename ComplexOrRealType>
+class OneLink
+{
+
+public:
+
+	using RealType = typename PsimagLite::Real<ComplexOrRealType>::Type;
+	using OldLambdaType = std::function<void(ComplexOrRealType&)>;
+	using LambdaType = std::function<void(ComplexOrRealType&, RealType, SizeType)>;
+	using VectorSizeType = std::vector<SizeType>;
+
+	OneLink(VectorSizeType indices_,
+	    VectorSizeType orbs_,
+	    ProgramGlobals::FermionOrBosonEnum fermionOrBoson_,
+	    PsimagLite::String mods_,
+	    SizeType angularMomentum_,
+	    RealType angularFactor_,
+	    SizeType category_,
+	    LambdaType vModifier_)
+	    : indices(indices_)
+	    , orbs(orbs_)
+	    , fermionOrBoson(fermionOrBoson_)
+	    , mods(mods_)
+	    , angularMomentum(angularMomentum_)
+	    , angularFactor(angularFactor_)
+	    , category(category_)
+	    , modifier(vModifier_)
+	{
+	}
+
+	OneLink(VectorSizeType indices_,
+	    VectorSizeType orbs_,
+	    ProgramGlobals::FermionOrBosonEnum fermionOrBoson_,
+	    PsimagLite::String mods_,
+	    SizeType angularMomentum_,
+	    RealType angularFactor_,
+	    SizeType category_,
+	    OldLambdaType vModifier_)
+	    : indices(indices_)
+	    , orbs(orbs_)
+	    , fermionOrBoson(fermionOrBoson_)
+	    , mods(mods_)
+	    , angularMomentum(angularMomentum_)
+	    , angularFactor(angularFactor_)
+	    , category(category_)
+	{
+		modifier = [vModifier_](ComplexOrRealType& value, RealType, SizeType) { vModifier_(value); };
+	}
+
+	VectorSizeType indices;
+	VectorSizeType orbs;
+	ProgramGlobals::FermionOrBosonEnum fermionOrBoson;
+	PsimagLite::String mods;
+	SizeType angularMomentum;
+	RealType angularFactor;
+	SizeType category;
+	LambdaType modifier;
+}; // OneLink
+}
+#endif // ONELINK_HH

--- a/src/Engine/SuperGeometry.h
+++ b/src/Engine/SuperGeometry.h
@@ -10,11 +10,14 @@ namespace Dmrg
 template <typename ComplexOrRealType_, typename InputType_, typename ProgramGlobalsType>
 class SuperGeometry
 {
+public:
 
 	typedef PsimagLite::Geometry<ComplexOrRealType_, InputType_, ProgramGlobalsType> GeometryType;
 	typedef typename GeometryType::ComplexOrRealType ComplexOrRealType;
 	typedef typename GeometryType::VectorSizeType VectorSizeType;
 	typedef typename PsimagLite::Vector<VectorSizeType>::Type VectorVectorSizeType;
+
+private:
 
 	class SuperPlaquette
 	{

--- a/src/Models/HubbardOneBand/ModelHubbard.h
+++ b/src/Models/HubbardOneBand/ModelHubbard.h
@@ -337,6 +337,7 @@ protected:
 	*/
 	void fillModelLinks()
 	{
+		constexpr bool isComplex = PsimagLite::IsComplexNumber<SparseElementType>::True;
 		ModelTermType& hop = ModelBaseType::createTerm("hopping"); //(A)
 
 		auto su2_up = typename ModelTermType::Su2Properties(1, 1, 0);
@@ -346,7 +347,7 @@ protected:
 		OpForLinkType cdown("c", 1); // (D)
 
 		if (extension_ == "Peierls") {
-			auto peierls = BuildPierls<SparseElementType>::lambda(modelParameters_.potentialA);
+			auto peierls = BuildPierls<SuperGeometryType, isComplex>::lambda(modelParameters_.potentialA);
 			hop.push(cup, 'N', cup, 'C', peierls, su2_up); // (C)
 			hop.push(cdown, 'N', cdown, 'C', peierls, su2_do);
 		} else {

--- a/src/Models/HubbardOneBand/ParametersModelHubbard.h
+++ b/src/Models/HubbardOneBand/ParametersModelHubbard.h
@@ -89,9 +89,10 @@ namespace Dmrg
 template <typename RealType, typename QnType>
 struct ParametersModelHubbard : public ParametersModelBase<RealType, QnType> {
 
-	typedef ParametersModelBase<RealType, QnType> BaseType;
-	typedef PsimagLite::InputNg<InputCheck>::Readable IoInputType;
-	typedef PsimagLite::Vector<PsimagLite::String>::Type VectorStringType;
+	using BaseType = ParametersModelBase<RealType, QnType>;
+	using IoInputType = PsimagLite::InputNg<InputCheck>::Readable;
+	using VectorStringType = PsimagLite::Vector<PsimagLite::String>::Type;
+	using VectorRealType = std::vector<RealType>;
 
 	ParametersModelHubbard(IoInputType& io)
 	    : BaseType(io, false)
@@ -123,9 +124,11 @@ struct ParametersModelHubbard : public ParametersModelBase<RealType, QnType> {
 		}
 
 		try {
-			io.readline(potentialA, "PotentialA=");
-			std::cout << "PotentialA=" << potentialA << "\n";
+			potentialA.resize(nsites, 0.0);
+			io.read(potentialA, "PotentialA");
+			std::cout << "Has PotentialA\n";
 		} catch (std::exception&) {
+			potentialA.clear();
 		}
 
 		if (magneticX.size() > 0 && magneticX.size() != nsites) {
@@ -149,7 +152,7 @@ struct ParametersModelHubbard : public ParametersModelBase<RealType, QnType> {
 
 	VectorStringType readOldT(IoInputType& io, SizeType nsites)
 	{
-		typename PsimagLite::Vector<RealType>::Type potentialTlegacy;
+		VectorRealType potentialTlegacy;
 		try {
 			io.read(potentialTlegacy, "PotentialT");
 			std::cerr << "Has PotentialT\n";
@@ -186,11 +189,11 @@ struct ParametersModelHubbard : public ParametersModelBase<RealType, QnType> {
 		return potentialTv;
 	}
 
-	typename PsimagLite::Vector<RealType>::Type hubbardU;
-	typename PsimagLite::Vector<RealType>::Type potentialV;
-	typename PsimagLite::Vector<RealType>::Type anisotropy;
-	typename PsimagLite::Vector<RealType>::Type magneticX;
-	RealType potentialA = 0.;
+	VectorRealType hubbardU;
+	VectorRealType potentialV;
+	VectorRealType anisotropy;
+	VectorRealType magneticX;
+	VectorRealType potentialA;
 
 	// for time-dependent H:
 	VectorStringType onSiteHaddLegacy;

--- a/src/Models/HubbardOneBand/PeierlsHopping.hh
+++ b/src/Models/HubbardOneBand/PeierlsHopping.hh
@@ -1,33 +1,46 @@
 #ifndef PEIERLSHOPPING_HH
 #define PEIERLSHOPPING_HH
 #include "Complex.h"
+#include <utility>
+#include <vector>
 
 namespace Dmrg
 {
 
-template <typename ComplexOrRealType>
+template <typename SuperGeometryType, bool>
 class BuildPierls
 {
 public:
 
+	using ComplexOrRealType = typename SuperGeometryType::ComplexOrRealType;
 	using RealType = typename PsimagLite::Real<ComplexOrRealType>::Type;
+	using VectorRealType = std::vector<RealType>;
 
-	static auto lambda(const RealType& A)
+	static auto lambda(const VectorRealType& A)
 	{
 		err("Cannot run Peierls Hubbard with reals; say usecomplex in SolverOptions\n");
-		return [A](ComplexOrRealType&, RealType) { };
+		return [A](ComplexOrRealType&, RealType, SizeType) { };
 	}
 };
 
-template <typename RealType>
-class BuildPierls<std::complex<RealType>>
+template <typename SuperGeometryType>
+class BuildPierls<SuperGeometryType, true>
 {
 public:
 
-	static auto lambda(const RealType& A)
+	using ComplexOrRealType = typename SuperGeometryType::ComplexOrRealType;
+	using RealType = typename PsimagLite::Real<ComplexOrRealType>::Type;
+	using VectorRealType = std::vector<RealType>;
+
+	static auto lambda(const VectorRealType& A)
 	{
-		return [A](std::complex<RealType>& hop, RealType t) {
-			RealType arg = A * t;
+		return [&A_const = std::as_const(A)](std::complex<RealType>& hop,
+			   RealType t,
+			   SizeType site) {
+			if (A_const.size() == 0)
+				return;
+			assert(site < A_const.size());
+			RealType arg = A_const[site] * t;
 			hop *= std::complex<RealType>(cos(arg), sin(arg));
 		};
 	}

--- a/src/Models/IsingMultiOrb/ModelIsingMultiOrb.h
+++ b/src/Models/IsingMultiOrb/ModelIsingMultiOrb.h
@@ -429,7 +429,7 @@ private:
 		const SizeType orbitals = modelParameters_.orbitals;
 		ModelTermType& szsz = ModelBaseType::createTerm("szsz");
 
-		auto mylambda = [this](ComplexOrRealType& coupling, RealType time) {
+		auto mylambda = [this](ComplexOrRealType& coupling, RealType time, SizeType) {
 			coupling = timeDependentConnection(coupling, time, 2);
 		};
 

--- a/src/Models/SuperExtendedHubbard1Orb/SuperExtendedHubbard1Orb.h
+++ b/src/Models/SuperExtendedHubbard1Orb/SuperExtendedHubbard1Orb.h
@@ -229,7 +229,7 @@ protected:
 		    'N',
 		    splus,
 		    'C',
-		    [isSu2](SparseElementType& value, RealType) { value *= (isSu2) ? -0.5 : 0.5; },
+		    [isSu2](SparseElementType& value, RealType, SizeType) { value *= (isSu2) ? -0.5 : 0.5; },
 		    typename ModelTermType::Su2Properties(2, -1, 2));
 
 		ModelTermType& szsz = ModelBaseType::createTerm("szsz");


### PR DESCRIPTION
Changes to code logic; Link modifiers now have two modes.

Model writers can pass a modifier to a Hamiltonian term (connection). This modifier is a C++ lambda with signature
```
(const ComplexOrRealType& connector_value)
```
or
```
(const ComplexOrRealType& connector_value, RealType time, unsigned int site)
```
and in both cases returns the modified connector value.

This PR adds the second option, and drops the old option where connector_value and time were allowed.

