### PR TITLE
CMake: Drop unwarranted compile options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,19 +3,6 @@ cmake_minimum_required(VERSION 3.21)
 find_package(PsimagLite REQUIRED CONFIG)
 find_package(Boost REQUIRED CONFIG)
 
-# Add -Wextra in the future
-add_compile_options(-Wall -DUSE_BOOST)
-
-# Not sure where to put the build types
-if (NOT  ${CMAKE_BUILD_TYPE}  STREQUAL "")
-  string(TOLOWER ${CMAKE_BUILD_TYPE} build_type)
-  if (build_type STREQUAL debug)
-    add_compile_options(-g3 -Werror)
-  else()
-    add_compile_options(-O3 -DNDEBUG)
-  endif()
-endif()
-
 add_custom_command(
   OUTPUT GitRevision.h
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/createGitRevision.pl GitRevision.h


### PR DESCRIPTION
Do not mess with options to request warnings.
Do not add compile options to set the build type either.