### PR TITLE
Embed PsimagLite build into dmrgcpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,7 @@ if(NOT QMC_CXX_STANDARD EQUAL 11)
   )
 endif()
 
-find_package(MPI COMPONENTS CXX)
-
-include(HandleHDF5)
-
-find_package(BLAS)
-find_package(LAPACK)
+include (CTest)
 
 add_subdirectory(PsimagLite)
 add_subdirectory(src)

--- a/PsimagLite/src/CMakeLists.txt
+++ b/PsimagLite/src/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(psimaglite::psimaglite ALIAS psimaglite)
 
 target_link_libraries(psimaglite PUBLIC loki)
 
-# find_package(MPI COMPONENTS CXX)
+find_package(MPI COMPONENTS CXX)
 if(MPI_FOUND)
   target_compile_definitions(psimaglite PUBLIC USE_MPI)
   target_link_libraries(psimaglite PUBLIC MPI::MPI_CXX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,12 +13,11 @@ add_subdirectory(KronUtil)
 
 add_library(Common OBJECT ProgramGlobals.cpp Provenance.cpp Utils.cpp)
 target_sources(Common PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/GitRevision.h)
-target_link_libraries(Common PRIVATE psimaglite::psimaglite
-                                     HDF5::HDF5)
+target_link_libraries(Common PRIVATE psimaglite::psimaglite)
 target_include_directories(Common PRIVATE ${CMAKE_CURRENT_BINARY_DIR} Engine)
 
 add_library(Su2Related OBJECT Su2Related.cpp)
-target_link_libraries(Su2Related PRIVATE psimaglite::psimaglite HDF5::HDF5)
+target_link_libraries(Su2Related PRIVATE psimaglite::psimaglite)
 target_include_directories(Su2Related PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
                                               Engine)
 
@@ -70,15 +69,10 @@ add_executable(dmrg $<TARGET_OBJECTS:Common> $<TARGET_OBJECTS:Su2Related>
 target_compile_definitions(dmrg PUBLIC USE_BOOST)
 
 target_link_libraries(
-  dmrg PUBLIC kronutil psimaglite::psimaglite HDF5::HDF5 BLAS::BLAS
-              LAPACK::LAPACK ${ADDITIONAL_LIBRARIES})
+  dmrg PUBLIC kronutil psimaglite::psimaglite
+              ${ADDITIONAL_LIBRARIES})
 target_include_directories(dmrg PRIVATE ${CMAKE_CURRENT_BINARY_DIR} Engine)
 target_sources(dmrg PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/GitRevision.h)
-
-if(MPI_FOUND)
-  target_compile_definitions(dmrg PUBLIC USE_MPI)
-  target_link_libraries(dmrg PUBLIC MPI::MPI_CXX)
-endif()
 
 # Observe executable below
 add_executable(
@@ -98,15 +92,12 @@ target_link_libraries(
   observe
   kronutil
   psimaglite::psimaglite
-  HDF5::HDF5
-  BLAS::BLAS
-  LAPACK::LAPACK
   ${ADDITIONAL_LIBRARIES})
 
 # Toolbox executable now
 add_executable(toolboxdmrg toolboxdmrg.cpp Qn.cpp ProgramGlobals.cpp
                            Provenance.cpp)
-target_link_libraries(toolboxdmrg psimaglite::psimaglite HDF5::HDF5
+target_link_libraries(toolboxdmrg psimaglite::psimaglite
                       ${ADDITIONAL_LIBRARIES})
 target_sources(toolboxdmrg PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/GitRevision.h)
 target_include_directories(toolboxdmrg PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
@@ -121,7 +112,4 @@ target_link_libraries(
   omegas
   kronutil
   psimaglite::psimaglite
-  HDF5::HDF5
-  BLAS::BLAS
-  LAPACK::LAPACK
   ${ADDITIONAL_LIBRARIES})

--- a/src/KronUtil/CMakeLists.txt
+++ b/src/KronUtil/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_library(kronutil KronUtil.cpp util.cpp utilComplex.cpp csc_nnz.cpp)
-target_link_libraries(kronutil PRIVATE psimaglite::psimaglite HDF5::HDF5)
+target_link_libraries(kronutil PRIVATE psimaglite::psimaglite)


### PR DESCRIPTION
Use `add_subdirectory(PsimagLite)` instead of searching for an external dependency.
Define a `psimaglite::psimaglite` alias target so we can refer to it just as if it was imported.
