### PR TITLE
Fix bitwise operation between different enumeration types warnings

### DIFF
--- a/PsimagLite/src/Matrix.h
+++ b/PsimagLite/src/Matrix.h
@@ -1111,7 +1111,7 @@ namespace MPI {
 
 	template <typename SomeMatrixType>
 	typename EnableIf<
-	    IsMatrixLike<SomeMatrixType>::True & Loki::TypeTraits<typename SomeMatrixType::value_type>::isArith,
+	    IsMatrixLike<SomeMatrixType>::True && Loki::TypeTraits<typename SomeMatrixType::value_type>::isArith,
 	    void>::Type
 	allReduce(SomeMatrixType& v, MPI_Op op = MPI_SUM, CommType mpiComm = MPI_COMM_WORLD)
 	{
@@ -1125,7 +1125,7 @@ namespace MPI {
 
 	template <typename SomeMatrixType>
 	typename EnableIf<
-	    IsMatrixLike<SomeMatrixType>::True & IsComplexNumber<typename SomeMatrixType::value_type>::True,
+	    IsMatrixLike<SomeMatrixType>::True && IsComplexNumber<typename SomeMatrixType::value_type>::True,
 	    void>::Type
 	allReduce(SomeMatrixType& v, MPI_Op op = MPI_SUM, CommType mpiComm = MPI_COMM_WORLD)
 	{

--- a/PsimagLite/src/MemResolv.h
+++ b/PsimagLite/src/MemResolv.h
@@ -314,7 +314,7 @@ public:
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & !IsClass<typename SomeVectorType::value_type>::value,
+	    IsVectorLike<SomeVectorType>::True && !IsClass<typename SomeVectorType::value_type>::value,
 	    SizeType>::Type
 	memResolv(const SomeVectorType* v, SizeType = 0, String msg = "")
 	{
@@ -340,7 +340,7 @@ public:
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & IsClass<typename SomeVectorType::value_type>::value,
+	    IsVectorLike<SomeVectorType>::True && IsClass<typename SomeVectorType::value_type>::value,
 	    SizeType>::Type
 	memResolv(const SomeVectorType* v, SizeType = 0, String msg = "")
 	{
@@ -363,7 +363,7 @@ public:
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & !IsClass<typename SomeVectorType::value_type>::value,
+	    IsVectorLike<SomeVectorType>::True && !IsClass<typename SomeVectorType::value_type>::value,
 	    SizeType>::Type
 	memResolvPtr(const SomeVectorType* v, SizeType = 0, String msg = "")
 	{
@@ -395,7 +395,7 @@ public:
 	}
 
 	template <typename SomeClassType>
-	typename EnableIf<!IsVectorLike<SomeClassType>::True & !IsPairLike<SomeClassType>::True & !IsMapLike<SomeClassType>::True & !IsComplexNumber<SomeClassType>::True & IsClass<SomeClassType>::value,
+	typename EnableIf<!IsVectorLike<SomeClassType>::True && !IsPairLike<SomeClassType>::True && !IsMapLike<SomeClassType>::True && !IsComplexNumber<SomeClassType>::True && IsClass<SomeClassType>::value,
 	                  SizeType>::Type
 	memResolv(const SomeClassType* c, SizeType x = 0, String msg = "")
 	{

--- a/PsimagLite/src/MpiYes.h
+++ b/PsimagLite/src/MpiYes.h
@@ -134,7 +134,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
+	    IsVectorLike<SomeVectorType>::True && Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
 	    void>::Type
 	recv(SomeVectorType& v, int source, int tag, CommType mpiComm = COMM_WORLD)
 	{
@@ -152,7 +152,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & IsComplexNumber<typename SomeVectorType::value_type>::True,
+	    IsVectorLike<SomeVectorType>::True && IsComplexNumber<typename SomeVectorType::value_type>::True,
 	    void>::Type
 	recv(SomeVectorType& v, int source, int tag, CommType mpiComm = COMM_WORLD)
 	{
@@ -187,7 +187,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
+	    IsVectorLike<SomeVectorType>::True && Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
 	    void>::Type
 	send(SomeVectorType& v, int dest, int tag, CommType mpiComm = COMM_WORLD)
 	{
@@ -202,7 +202,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & IsComplexNumber<typename SomeVectorType::value_type>::True,
+	    IsVectorLike<SomeVectorType>::True && IsComplexNumber<typename SomeVectorType::value_type>::True,
 	    void>::Type
 	send(SomeVectorType& v, int dest, int tag, CommType mpiComm = COMM_WORLD)
 	{
@@ -255,7 +255,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & !IsVectorLike<typename SomeVectorType::value_type>::True & !Loki::TypeTraits<typename SomeVectorType::value_type>::isArith & !IsPairLike<typename SomeVectorType::value_type>::True,
+	    IsVectorLike<SomeVectorType>::True && !IsVectorLike<typename SomeVectorType::value_type>::True && !Loki::TypeTraits<typename SomeVectorType::value_type>::isArith && !IsPairLike<typename SomeVectorType::value_type>::True,
 	    void>::Type
 	pointByPointGather(SomeVectorType& v, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -288,7 +288,7 @@ namespace MPI {
 	}
 
 	template <typename SomeVectorType>
-	typename EnableIf<IsVectorLike<SomeVectorType>::True & IsPairLike<typename SomeVectorType::value_type>::True,
+	typename EnableIf<IsVectorLike<SomeVectorType>::True && IsPairLike<typename SomeVectorType::value_type>::True,
 	                  void>::Type
 	pointByPointGather(SomeVectorType& v, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -322,7 +322,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & IsVectorLike<typename SomeVectorType::value_type>::True & Loki::TypeTraits<typename SomeVectorType::value_type::value_type>::isArith,
+	    IsVectorLike<SomeVectorType>::True && IsVectorLike<typename SomeVectorType::value_type>::True && Loki::TypeTraits<typename SomeVectorType::value_type::value_type>::isArith,
 	    void>::Type
 	bcast(SomeVectorType& v, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -352,7 +352,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
+	    IsVectorLike<SomeVectorType>::True && Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
 	    void>::Type
 	bcast(SomeVectorType& v, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -367,7 +367,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & IsComplexNumber<typename SomeVectorType::value_type>::True,
+	    IsVectorLike<SomeVectorType>::True && IsComplexNumber<typename SomeVectorType::value_type>::True,
 	    void>::Type
 	bcast(SomeVectorType& v, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -377,7 +377,7 @@ namespace MPI {
 	}
 
 	template <typename T1, typename T2>
-	typename EnableIf<Loki::TypeTraits<T1>::isArith & Loki::TypeTraits<T2>::isArith,
+	typename EnableIf<Loki::TypeTraits<T1>::isArith && Loki::TypeTraits<T2>::isArith,
 	                  void>::Type
 	bcast(std::pair<T1, T2>& p, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -394,7 +394,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & !IsVectorLike<typename SomeVectorType::value_type>::True & !Loki::TypeTraits<typename SomeVectorType::value_type>::isArith & !IsComplexNumber<typename SomeVectorType::value_type>::True,
+	    IsVectorLike<SomeVectorType>::True && !IsVectorLike<typename SomeVectorType::value_type>::True && !Loki::TypeTraits<typename SomeVectorType::value_type>::isArith && !IsComplexNumber<typename SomeVectorType::value_type>::True,
 	    void>::Type
 	bcast(SomeVectorType& v, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -405,7 +405,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
+	    IsVectorLike<SomeVectorType>::True && Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
 	    void>::Type
 	reduce(SomeVectorType& v, MPI_Op op = MPI_SUM, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -422,7 +422,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & IsComplexNumber<typename SomeVectorType::value_type>::True,
+	    IsVectorLike<SomeVectorType>::True && IsComplexNumber<typename SomeVectorType::value_type>::True,
 	    void>::Type
 	reduce(SomeVectorType& v, MPI_Op op = MPI_SUM, int root = 0, CommType mpiComm = COMM_WORLD)
 	{
@@ -439,7 +439,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
+	    IsVectorLike<SomeVectorType>::True && Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
 	    void>::Type
 	allReduce(SomeVectorType& v, MPI_Op op = MPI_SUM, CommType mpiComm = COMM_WORLD)
 	{
@@ -452,7 +452,7 @@ namespace MPI {
 
 	template <typename SomeVectorType>
 	typename EnableIf<
-	    IsVectorLike<SomeVectorType>::True & IsComplexNumber<typename SomeVectorType::value_type>::True,
+	    IsVectorLike<SomeVectorType>::True && IsComplexNumber<typename SomeVectorType::value_type>::True,
 	    void>::Type
 	allReduce(SomeVectorType& v, MPI_Op op = MPI_SUM, CommType mpiComm = COMM_WORLD)
 	{


### PR DESCRIPTION
We are getting tons of these
```
/path/to/dmrgpp/PsimagLite/src/MpiYes.h:442:41: warning: bitwise operation between different enumeration types ('PsimagLite::IsVectorLike<std::vector<double>>::(unnamed enum at /path/to/dmrgpp/PsimagLite/src/Vector.h:69:2)' and 'Loki::TypeTraits<double>::(unnamed enum at /path/to/dmrgpp/PsimagLite/src/../loki/TypeTraits.h:4008:2)') is deprecated [-Wdeprecated-anon-enum-enum-conversion]
  442 |             IsVectorLike<SomeVectorType>::True & Loki::TypeTraits<typename SomeVectorType::value_type>::isArith,
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```