### PR TITLE
Resolve unused but set warning about error code returned by MPI_Bcast

### DIFF
--- a/PsimagLite/src/MpiYes.h
+++ b/PsimagLite/src/MpiYes.h
@@ -384,6 +384,7 @@ namespace MPI {
 		T1 t1 = p.first;
 		MPI_Datatype datatype = MpiData<T1>::Type;
 		int errorCode = MPI_Bcast(&t1, 1, datatype, root, mpiComm);
+		(void)errorCode;
 
 		T2 t2 = p.second;
 		MPI_Datatype datatype2 = MpiData<T2>::Type;


### PR DESCRIPTION
We are getting warning about not using the error code value returned by `MPI_Bcast`.
```
/path/to/dmrgpp/PsimagLite/src/MpiYes.h:386:7: warning: variable 'errorCode' set but not used [-Wunused-but-set-variable]
  386 |                 int errorCode = MPI_Bcast(&t1, 1, datatype, root, mpiComm);
      |                     ^
```
Here I opted for suppressing the warning via a C-style cast to void to tell the compiler the value is unused but we could also call `checkError` if you prefer.