### PR TITLE
Optionally dumps Hamiltonian as CRS matrix and init vector

### DIFF
--- a/TestSuite/inputs/input8800.ain
+++ b/TestSuite/inputs/input8800.ain
@@ -14,10 +14,10 @@ gt1:dir0:Connectors=[1.0];
 Model="Heisenberg";
 HeisenbergTwiceS=1;
 
-SolverOptions="twositedmrg,usecomplex,debugmatrix";
+SolverOptions="twositedmrg,debugmatrix";
 Version="247b335fe1542909b90be8647456bfd8fd56191c";
 OutputFile="data8800";
 InfiniteLoopKeptStates=60;
-FiniteLoops=[[3, 100, 0],[-6, 100, 0]];
+FiniteLoops=[[@auto, 100, 0],[@auto, 100, 0]];
 TargetSzPlusConst=4;
 DumpHamiltonian="s==4";

--- a/TestSuite/inputs/input8800.ain
+++ b/TestSuite/inputs/input8800.ain
@@ -1,0 +1,23 @@
+##Ainur 1.0
+
+TotalNumberOfSites=8;
+NumberOfTerms=2;
+
+gt0:GeometryKind="chain";
+gt0:GeometryOptions="ConstantValues";
+gt0:dir0:Connectors=[1.0];
+
+gt1:GeometryKind="chain";
+gt1:GeometryOptions="ConstantValues";
+gt1:dir0:Connectors=[1.0];
+
+Model="Heisenberg";
+HeisenbergTwiceS=1;
+
+SolverOptions="twositedmrg,usecomplex,debugmatrix";
+Version="247b335fe1542909b90be8647456bfd8fd56191c";
+OutputFile="data8800";
+InfiniteLoopKeptStates=60;
+FiniteLoops=[[3, 100, 0],[-6, 100, 0]];
+TargetSzPlusConst=4;
+DumpHamiltonian="s==4";

--- a/doc/DumpHamiltonian.txt
+++ b/doc/DumpHamiltonian.txt
@@ -1,0 +1,27 @@
+[Needs integration into manual]
+
+See input8800.ain
+
+Note that
+SolverOptions=debugmatrix
+
+this enables computing the CRS
+at every step
+
+then set
+DumpHamiltonian="predicate";
+
+where predicate is explained
+at the beginning of file
+PsimagLite/src/PredicateAwesome.h
+and in this case it can use two
+variables
+s for sites
+l for loopIndex
+
+The filename will be
+$root followed by _dump.txt
+For example, running
+dmrg -f input8800.ain
+will create
+runForinput8800_dump.txt

--- a/src/Engine/DumpHamiltonian.hh
+++ b/src/Engine/DumpHamiltonian.hh
@@ -68,7 +68,10 @@ public:
 		fout_ << "Instance=" << counter_ << "\n";
 		fout_ << "Loop=" << loop_site_dir.loopIndex << "\n";
 		fout_ << "Site=" << loop_site_dir.site << "\n";
-
+		fout_ << "CRS_Matrix_follows\n";
+		fout_ << crs;
+		fout_ << "InitVector_follows\n";
+		fout_ << initial_vector;
 		++counter_;
 	}
 

--- a/src/Engine/DumpHamiltonian.hh
+++ b/src/Engine/DumpHamiltonian.hh
@@ -1,0 +1,85 @@
+#ifndef DUMPHAMILTONIAN_HH
+#define DUMPHAMILTONIAN_HH
+#include "CrsMatrix.h"
+#include "LoopSiteDirection.hh"
+#include "PredicateAwesome.h"
+#include "ProgramGlobals.h"
+#include "Vector.h"
+#include <fstream>
+#include <string>
+
+namespace Dmrg
+{
+
+template <typename ParametersDmrgType, typename ComplexOrRealType>
+class DumpHamiltonian
+{
+
+public:
+
+	using VectorType = std::vector<ComplexOrRealType>;
+	using SparseMatrixType = PsimagLite::CrsMatrix<ComplexOrRealType>;
+
+	DumpHamiltonian(const ParametersDmrgType& parameters)
+	    : parameters_(parameters)
+	    , predicate_(parameters.dumpHamiltonian)
+	    , enabled_(parameters.options.isSet("debugmatrix") && !predicate_.empty())
+	    , counter_(0)
+	    , filename_(ProgramGlobals::rootName(parameters.filename) + "_dumpH.txt")
+	{
+		if (!enabled_) {
+			return;
+		}
+
+		fout_.open(filename_.c_str());
+		fout_.precision(parameters_.precision);
+		fout_ << "DumpHamiltonian for DMRG++ version " << DMRGPP_VERSION << "\n";
+	}
+
+	~DumpHamiltonian()
+	{
+		if (!enabled_) {
+			return;
+		}
+
+		fout_.close();
+		std::cout << "DumpHamiltonian: file " << filename_ << " has been written.\n";
+	}
+
+	void save(const SparseMatrixType& crs, const VectorType& initial_vector, const LoopSiteDirection& loop_site_dir)
+	{
+		if (!enabled_) {
+			return;
+		}
+
+		if (loop_site_dir.direction == ProgramGlobals::DirectionEnum::INFINITE) {
+			return;
+		}
+
+		std::string predicate = predicate_;
+		PsimagLite::replaceAll(predicate, "s", ttos(loop_site_dir.site));
+		PsimagLite::PredicateAwesome<> pAwesome(predicate);
+		bool b = pAwesome.isTrue("l", loop_site_dir.loopIndex);
+
+		if (!b) {
+			return;
+		}
+
+		fout_ << "Instance=" << counter_ << "\n";
+		fout_ << "Loop=" << loop_site_dir.loopIndex << "\n";
+		fout_ << "Site=" << loop_site_dir.site << "\n";
+
+		++counter_;
+	}
+
+private:
+
+	const ParametersDmrgType& parameters_;
+	std::string predicate_;
+	SizeType counter_;
+	std::string filename_;
+	bool enabled_;
+	std::ofstream fout_;
+};
+}
+#endif // DUMPHAMILTONIAN_HH

--- a/src/Engine/InputCheck.h
+++ b/src/Engine/InputCheck.h
@@ -295,6 +295,7 @@ public:
 		str += "string TargetFermionicParity;\n";
 		str += "matrix TimeSchedule;\n";
 		str += "string DefineOperators;\n";
+		str += "string DumpHamiltonian;\n";
 
 		return str;
 	}

--- a/src/Engine/LoopSiteDirection.hh
+++ b/src/Engine/LoopSiteDirection.hh
@@ -1,0 +1,16 @@
+#ifndef LOOPSITEDIRECTION_HH
+#define LOOPSITEDIRECTION_HH
+#include "ProgramGlobals.h"
+#include "Vector.h"
+
+namespace Dmrg
+{
+
+struct LoopSiteDirection {
+	SizeType loopIndex;
+	SizeType site;
+	ProgramGlobals::DirectionEnum direction;
+};
+
+}
+#endif // LOOPSITEDIRECTION_HH

--- a/src/Engine/ParametersDmrgSolver.h
+++ b/src/Engine/ParametersDmrgSolver.h
@@ -179,6 +179,7 @@ struct ParametersDmrgSolver {
 	VectorFiniteLoopType finiteLoop;
 	FieldType degeneracyMax;
 	FieldType denseSparseThreshold;
+	std::string dumpHamiltonian;
 
 	void write(PsimagLite::String label,
 	    PsimagLite::IoSerializer& ioSerializer) const
@@ -353,6 +354,15 @@ struct ParametersDmrgSolver {
 		try {
 			io.readline(dumperEnd, "KroneckerDumperEnd=");
 		} catch (std::exception&) {
+		}
+
+		try {
+			io.readline(dumpHamiltonian, "DumpHamiltonian=");
+		} catch (std::exception&) {
+		}
+
+		if (!dumpHamiltonian.empty() && !options.isSet("debugmatrix")) {
+			err("FATAL: DumpHamiltonian set without debugmatrix option\n");
 		}
 
 		if (options.isSet("KroneckerDumper")) {


### PR DESCRIPTION
Rationale: For debugging purposes, one sometimes wants to save the full Hamiltonian in CRS format to disk, and also the init vector to be used by Lanczos.

Read https://github.com/g1257/dmrgpp/blob/dump_hamiltonian/doc/DumpHamiltonian.txt
and the awesome predicate can be read at https://github.com/g1257/dmrgpp/blob/dump_hamiltonian/PsimagLite/src/PredicateAwesome.h#L10
 
In the 8800 example, I used
DumpHamiltonian="s==4";
which means that it dumps only for site == 4.
The other variable you can use is l, for loop number.
 
**Implementation**
Just FYI, the implementation hooks from 
https://github.com/g1257/dmrgpp/blob/dump_hamiltonian/src/Engine/Diagonalization.h#L828
and in in this file you can search dumpHamiltonian_ object, which is of class
https://github.com/g1257/dmrgpp/blob/dump_hamiltonian/src/Engine/DumpHamiltonian.hh