### PR TITLE
Documents that master is now the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ cd ../
 git clone https://github.com/g1257/dmrgpp.git
 cd dmrgpp/
 </pre>
-Users should clone and work with the `master` branch.
 Pull requests should be opened against the `master` branch.
 
 ### Configure


### PR DESCRIPTION
This PR documents that master is now the default branch, and features is no longer used.
Moreover, we should probably delete features to avoid confusion.
