### PR TITLE
Time Step Parameters: Damping added

### DIFF
--- a/src/Engine/InputCheck.h
+++ b/src/Engine/InputCheck.h
@@ -254,6 +254,7 @@ public:
 		str += "string TSPAlgorithm;\n";
 		str += "vector.integer TSPSites;\n";
 		str += "vector.integer TSPLoops;\n";
+		str += "real TSPDamping;\n";
 		str += "string TSPProductOrSum;\n";
 		str += "string TSPOperator;\n";
 		str += "string OperatorExpression;\n";

--- a/src/Engine/TargetParamsTimeStep.h
+++ b/src/Engine/TargetParamsTimeStep.h
@@ -99,17 +99,25 @@ public:
 	TargetParamsTimeStep(IoInputter& io, PsimagLite::String targeting, const ModelType& model)
 	    : TimeVectorParamsType(io, targeting, model)
 	    , maxTime_(0)
+	    , eta_(0)
 	{
 		try {
 			io.readline(maxTime_, "TSPMaxTime=");
+		} catch (std::exception&) { }
+
+		try {
+			io.readline(eta_, "TSPDamping=");
 		} catch (std::exception&) { }
 	}
 
 	virtual RealType maxTime() const { return maxTime_; }
 
+	RealType eta() const { return eta_; }
+
 private:
 
 	RealType maxTime_;
+	RealType eta_;
 }; // class TargetParamsTimeStep
 
 template <typename ModelType>

--- a/src/Engine/TargetParamsTimeStep.h
+++ b/src/Engine/TargetParamsTimeStep.h
@@ -99,25 +99,17 @@ public:
 	TargetParamsTimeStep(IoInputter& io, PsimagLite::String targeting, const ModelType& model)
 	    : TimeVectorParamsType(io, targeting, model)
 	    , maxTime_(0)
-	    , eta_(0)
 	{
 		try {
 			io.readline(maxTime_, "TSPMaxTime=");
-		} catch (std::exception&) { }
-
-		try {
-			io.readline(eta_, "TSPDamping=");
 		} catch (std::exception&) { }
 	}
 
 	virtual RealType maxTime() const { return maxTime_; }
 
-	RealType eta() const { return eta_; }
-
 private:
 
 	RealType maxTime_;
-	RealType eta_;
 }; // class TargetParamsTimeStep
 
 template <typename ModelType>

--- a/src/Engine/TargetParamsTimeVectors.h
+++ b/src/Engine/TargetParamsTimeVectors.h
@@ -101,6 +101,7 @@ public:
 	    , algorithm_(BaseType::AlgorithmEnum::KRYLOV)
 	    , tau_(0)
 	    , timeDirection_(1.0)
+	    , eta_(0)
 	{
 		/*PSIDOC TargetParamsTimeVectors
 		\item[TSPTau] [RealType], $\tau$ for the Krylov,
@@ -130,6 +131,10 @@ public:
 		try {
 			io.readline(timeDirection_, "TSPTimeFactor=");
 		} catch (std::exception&) { }
+
+		try {
+			io.readline(eta_, "TSPDamping=");
+		} catch (std::exception&) { }
 	}
 
 	virtual VectorRealType& times() { return times_; }
@@ -145,6 +150,8 @@ public:
 	virtual RealType timeDirection() const { return timeDirection_; }
 
 	virtual const VectorRealType& chebyTransform() const { return chebyTransform_; }
+
+	RealType eta() const { return eta_; }
 
 	template <typename IoInputter>
 	void setAlgorithm(VectorRealType* chebyTransform, PsimagLite::String s, IoInputter* io)
@@ -182,6 +189,7 @@ private:
 	typename BaseType::AlgorithmEnum algorithm_;
 	RealType                         tau_;
 	RealType                         timeDirection_;
+	RealType                         eta_;
 	VectorRealType                   chebyTransform_;
 }; // class TargetParamsTimeVectors
 
@@ -194,6 +202,7 @@ inline std::ostream& operator<<(std::ostream& os, const TargetParamsTimeVectors<
 	os << "TargetParams.advanceEach=" << t.advanceEach() << "\n";
 	os << "TargetParams.algorithm=" << t.algorithm() << "\n";
 	os << "TargetParams.timeDirection=" << t.timeDirection() << "\n";
+	os << "TargetParams.eta=" << t.eta() << "\n";
 	return os;
 }
 } // namespace Dmrg

--- a/src/Engine/TimeVectorsKrylov.h
+++ b/src/Engine/TimeVectorsKrylov.h
@@ -276,13 +276,15 @@ private:
 		for (SizeType ii = 0; ii < phi.sectors(); ++ii) {
 			const RealType        time          = times[timeIndex];
 			const RealType        timeDirection = tstStruct_.timeDirection();
+			const RealType        damping       = exp(-time * tstStruct_.eta());
 			const VectorRealType& eigsii        = eigs[ii];
-			auto                  action = [eigsii, Eg, time, timeDirection](SizeType k)
+			auto action = [eigsii, Eg, time, timeDirection, damping](SizeType k)
 			{
 				RealType          tmp = (eigsii[k] - Eg) * time * timeDirection;
 				ComplexOrRealType c   = 0.0;
 				PsimagLite::expComplexOrReal(c, -tmp);
-				return c;
+				assert(damping <= 1.);
+				return c * damping;
 			};
 
 			SizeType   i0 = phi.sector(ii);


### PR DESCRIPTION
Instead of doing exp(-i(H-Eg)t)|v> we no do exp(-i damping t)  exp(-i(H-Eg)t)|v> where damping is an optional input label called TSPDamping and it defaults to 0.
Rationale: This helps to compare the Fourier transforms time --> omega and viceversa, by using TSPDamping in one case, and TSPEta in the other.
TSP means ime Step Parameter.

A test is missing (TODO FIXME).
