### PR TITLE
Require C++17 support

### DIFF
--- a/PsimagLite/src/CMakeLists.txt
+++ b/PsimagLite/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
 target_include_directories(psimaglite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/Io
                                              ${CMAKE_CURRENT_SOURCE_DIR}/Ainur)
 
+target_compile_features(psimaglite PUBLIC cxx_std_17)
 target_link_libraries(psimaglite PUBLIC loki)
 
 add_library(psimaglite::psimaglite ALIAS psimaglite)


### PR DESCRIPTION
Use `target_compile_features` to specify the minimum cxx standard requirement for PsimagLite.
Targets that link against `psimaglite::psimaglite` will inherit that property transitively.