### PR TITLE
Add BUILD_TESTING option to control whether to enable tests or not

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,19 @@ project(
   VERSION 1.1
   LANGUAGES CXX)
 
-include(CTest)
+option(BUILD_TESTING "Enable building tests" ON)
+if(BUILD_TESTING)
+  enable_testing()
 
-include(FetchContent)
-FetchContent_Declare(
-  Catch2
-  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG v3.11.0
-  SYSTEM FIND_PACKAGE_ARGS NAMES Catch2)
-FetchContent_MakeAvailable(Catch2)
-include(Catch)
+  include(FetchContent)
+  FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.11.0
+    SYSTEM FIND_PACKAGE_ARGS NAMES Catch2)
+  FetchContent_MakeAvailable(Catch2)
+  include(Catch)
+endif()
 
 add_subdirectory(PsimagLite)
 add_subdirectory(src)

--- a/PsimagLite/CMakeLists.txt
+++ b/PsimagLite/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(loki)
 add_subdirectory(src)
-add_subdirectory(examples)
+if(BUILD_TESTING)
+  add_subdirectory(examples)
+endif()

--- a/PsimagLite/src/CMakeLists.txt
+++ b/PsimagLite/src/CMakeLists.txt
@@ -77,4 +77,6 @@ find_package(GSL REQUIRED)
 target_compile_definitions(psimaglite PUBLIC USE_GSL)
 target_link_libraries(psimaglite PUBLIC GSL::gsl)
 
-add_subdirectory(tests)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/src/KronUtil/CMakeLists.txt
+++ b/src/KronUtil/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(kronutil KronUtil.cpp util.cpp utilComplex.cpp csc_nnz.cpp)
 target_link_libraries(kronutil PUBLIC psimaglite::psimaglite)
 
-add_executable(KronUtil_Test1 test1.cpp)
-target_link_libraries(KronUtil_Test1 kronutil)
-add_test(NAME KronUtil_Test1 COMMAND KronUtil_Test1)
+if(BUILD_TESTING)
+  add_executable(KronUtil_Test1 test1.cpp)
+  target_link_libraries(KronUtil_Test1 kronutil)
+  add_test(NAME KronUtil_Test1 COMMAND KronUtil_Test1)
 
-add_executable(KronUtil_Test2 test2.cpp)
-target_link_libraries(KronUtil_Test2 kronutil)
-add_test(NAME KronUtil_Test2 COMMAND KronUtil_Test2)
+  add_executable(KronUtil_Test2 test2.cpp)
+  target_link_libraries(KronUtil_Test2 kronutil)
+  add_test(NAME KronUtil_Test2 COMMAND KronUtil_Test2)
+endif()


### PR DESCRIPTION
Introduce an option that can be leveraged to disable the tests.
In the current version, I called that option [BUILD_TESTING](https://cmake.org/cmake/help/latest/variable/BUILD_TESTING.html#build-testing) but we can call it whatever we want.
It is ON by default, meaning to disable the test, one would configure with `-DBUILD_TESTING=OFF`
