### PR TITLE
TimeDepConnections: Part III

### DIFF
--- a/PsimagLite/src/AST/Node.h
+++ b/PsimagLite/src/AST/Node.h
@@ -17,6 +17,7 @@ Please see full open source license included in file LICENSE.
 #ifndef PSI_NODE_H
 #define PSI_NODE_H
 #include "../Vector.h"
+#include "TypeToString.h"
 #include <cassert>
 
 namespace PsimagLite {
@@ -113,7 +114,11 @@ public:
 
 	virtual ValueType exec(const VectorValueType& v) const
 	{
-		assert(v.size() == 2);
+		if (v.size() != 2) {
+			throw RuntimeError("Expected two arguments for operator *, but found "
+			                   + ttos(v.size()) + "\n");
+		}
+
 		return v[0] * v[1];
 	}
 
@@ -125,9 +130,19 @@ template <typename VectorValueType> class DividedBy : public Node<VectorValueTyp
 
 public:
 
+	enum Kind
+	{
+		FLOATING_POINT,
+		INTEGER
+	};
+
+	DividedBy(Kind kind)
+	    : kind_(kind)
+	{ }
+
 	DividedBy* clone() const { return new DividedBy(*this); }
 
-	virtual PsimagLite::String code() const { return "/"; }
+	virtual PsimagLite::String code() const { return (kind_ == FLOATING_POINT) ? "/" : "i/"; }
 
 	virtual SizeType arity() const { return 2; }
 
@@ -135,10 +150,26 @@ public:
 	{
 		assert(v.size() == 2);
 		if (std::norm(v[1]) < 1e-6)
-			return v[0];
+			return byKind(v[0], 1.);
 
-		return v[0] / v[1];
+		return byKind(v[0], v[1]);
 	}
+
+private:
+
+	ValueType byKind(const ValueType& num, const ValueType& denom) const
+	{
+		return (kind_ == FLOATING_POINT) ? num / denom : toInteger(num, denom);
+	}
+
+	static ValueType toInteger(const ValueType& num, const ValueType& denom)
+	{
+		assert(std::real(denom) != 0);
+		int ret = std::real(num) / std::real(denom);
+		return ret;
+	}
+
+	Kind kind_;
 
 }; // class DividedBy
 

--- a/PsimagLite/src/AST/Node.h
+++ b/PsimagLite/src/AST/Node.h
@@ -130,7 +130,7 @@ template <typename VectorValueType> class DividedBy : public Node<VectorValueTyp
 
 public:
 
-	enum Kind
+	enum class Kind
 	{
 		FLOATING_POINT,
 		INTEGER
@@ -142,7 +142,10 @@ public:
 
 	DividedBy* clone() const { return new DividedBy(*this); }
 
-	virtual PsimagLite::String code() const { return (kind_ == FLOATING_POINT) ? "/" : "i/"; }
+	virtual PsimagLite::String code() const
+	{
+		return (kind_ == Kind::FLOATING_POINT) ? "/" : "i/";
+	}
 
 	virtual SizeType arity() const { return 2; }
 
@@ -159,7 +162,7 @@ private:
 
 	ValueType byKind(const ValueType& num, const ValueType& denom) const
 	{
-		return (kind_ == FLOATING_POINT) ? num / denom : toInteger(num, denom);
+		return (kind_ == Kind::FLOATING_POINT) ? num / denom : toInteger(num, denom);
 	}
 
 	static ValueType toInteger(const ValueType& num, const ValueType& denom)

--- a/PsimagLite/src/AST/PlusMinusMultiplyDivide.h
+++ b/PsimagLite/src/AST/PlusMinusMultiplyDivide.h
@@ -53,8 +53,11 @@ public:
 		NodeType* times = new TimesType();
 		nodes_.push_back(times);
 
-		NodeType* dividedBy = new DividedByType();
-		nodes_.push_back(dividedBy);
+		NodeType* dividedByF = new DividedByType(DividedByType::FLOATING_POINT);
+		nodes_.push_back(dividedByF);
+
+		NodeType* dividedByI = new DividedByType(DividedByType::INTEGER);
+		nodes_.push_back(dividedByI);
 
 		NodeType* modulus = new ModulusType();
 		nodes_.push_back(modulus);

--- a/PsimagLite/src/AST/PlusMinusMultiplyDivide.h
+++ b/PsimagLite/src/AST/PlusMinusMultiplyDivide.h
@@ -53,10 +53,10 @@ public:
 		NodeType* times = new TimesType();
 		nodes_.push_back(times);
 
-		NodeType* dividedByF = new DividedByType(DividedByType::FLOATING_POINT);
+		NodeType* dividedByF = new DividedByType(DividedByType::Kind::FLOATING_POINT);
 		nodes_.push_back(dividedByF);
 
-		NodeType* dividedByI = new DividedByType(DividedByType::INTEGER);
+		NodeType* dividedByI = new DividedByType(DividedByType::Kind::INTEGER);
 		nodes_.push_back(dividedByI);
 
 		NodeType* modulus = new ModulusType();

--- a/PsimagLite/src/Ainur/AinurMacros.hh
+++ b/PsimagLite/src/Ainur/AinurMacros.hh
@@ -113,6 +113,8 @@ public:
 		static bool emptyLine(const std::string& s)
 		{
 			for (SizeType i = 0; i < s.size(); ++i) {
+				if (s[i] == '#')
+					return true;
 				if (s[i] != ' ' || s[i] != '\t')
 					return false;
 			}

--- a/PsimagLite/src/Ainur/AinurMacros.hh
+++ b/PsimagLite/src/Ainur/AinurMacros.hh
@@ -112,15 +112,10 @@ public:
 
 		static bool emptyLine(const std::string& s)
 		{
-			for (SizeType i = 0; i < s.size(); ++i) {
-				if (s[i] == '#')
-					return true;
-				if (s[i] != ' ' || s[i] != '\t')
-					return false;
-			}
-
-			return true;
+			SizeType r = s.find_first_not_of("# \t");
+			return (r == std::string::npos);
 		}
+
 		void readData()
 		{
 			std::ifstream fin(filename_);

--- a/PsimagLite/src/Ainur/test.cpp
+++ b/PsimagLite/src/Ainur/test.cpp
@@ -41,7 +41,10 @@ int main(int argc, char** argv)
 
 	PsimagLite::String str;
 	for (int i = 1; i < argc; ++i) {
-		std::ifstream      fin(argv[i]);
+		std::ifstream fin(argv[i]);
+		if (!fin || fin.bad() || !fin.good()) {
+			throw std::runtime_error(std::string("Cannot open ") + argv[i] + "\n");
+		}
 		PsimagLite::String str2;
 
 		fin.seekg(0, std::ios::end);

--- a/PsimagLite/src/Geometry/GeometryDirection.h
+++ b/PsimagLite/src/Geometry/GeometryDirection.h
@@ -174,12 +174,6 @@ public:
 		rawHoppings_.write(label + "/rawHoppings_", ioSerializer);
 	}
 
-	template <typename SomeMemResolvType>
-	SizeType memResolv(SomeMemResolvType&, SizeType, String) const
-	{
-		return 0;
-	}
-
 	ComplexOrRealType operator()(SizeType i, SizeType edof1, SizeType j, SizeType edof2) const
 	{
 		SizeType ii = edof1 + i * aux_.orbitals;

--- a/PsimagLite/src/Geometry/GeometryDirection.h
+++ b/PsimagLite/src/Geometry/GeometryDirection.h
@@ -174,6 +174,12 @@ public:
 		rawHoppings_.write(label + "/rawHoppings_", ioSerializer);
 	}
 
+	template <typename SomeMemResolvType>
+	SizeType memResolv(SomeMemResolvType&, SizeType, String) const
+	{
+		return 0;
+	}
+
 	ComplexOrRealType operator()(SizeType i, SizeType edof1, SizeType j, SizeType edof2) const
 	{
 		SizeType ii = edof1 + i * aux_.orbitals;

--- a/PsimagLite/src/Geometry/GeometryTerm.h
+++ b/PsimagLite/src/Geometry/GeometryTerm.h
@@ -169,6 +169,10 @@ public:
 		String s;
 		io.readline(s, "GeometryKind=");
 
+		try {
+			io.readline(gFactor_, "GeometryFactor=");
+		} catch (std::exception&) { }
+
 		io.readline(gOptions_, "GeometryOptions=");
 		bool constantValues = (gOptions_.find("ConstantValues") != String::npos);
 
@@ -246,7 +250,7 @@ public:
 		ioSerializer.createGroup(label);
 		aux_.write(label + "/aux_", ioSerializer);
 		ioSerializer.write(label + "/orbitals_", orbitals_);
-		// geometryBase_->write(label + "/geometryBase_", ioSerializer);
+		ioSerializer.write(label + "/gFactor_", gFactor_);
 		ioSerializer.write(label + "/gOptions_", gOptions_);
 		ioSerializer.write(label + "/directions_", directions_);
 		cachedValues_.write(label + "/cachedValues_", ioSerializer);
@@ -413,6 +417,8 @@ public:
 
 	String options() const { return gOptions_; }
 
+	std::string factor() const { return gFactor_; }
+
 	friend std::ostream& operator<<(std::ostream& os, const GeometryTerm& gt)
 	{
 		os << "#GeometryDirections=" << gt.directions_.size() << "\n";
@@ -478,6 +484,7 @@ private:
 	SizeType                                     orbitals_;
 	GeometryBaseType*                            geometryBase_;
 	String                                       gOptions_;
+	std::string                                  gFactor_;
 	typename Vector<GeometryDirectionType>::Type directions_;
 	Matrix<ComplexOrRealType>                    cachedValues_;
 }; // class GeometryTerm

--- a/PsimagLite/src/Geometry/GeometryTerm.h
+++ b/PsimagLite/src/Geometry/GeometryTerm.h
@@ -417,7 +417,7 @@ public:
 
 	const std::string& options() const { return gOptions_; }
 
-	const std::string & factor() const { return gFactor_; }
+	const std::string& factor() const { return gFactor_; }
 
 	friend std::ostream& operator<<(std::ostream& os, const GeometryTerm& gt)
 	{

--- a/PsimagLite/src/Geometry/GeometryTerm.h
+++ b/PsimagLite/src/Geometry/GeometryTerm.h
@@ -417,7 +417,7 @@ public:
 
 	const std::string& options() const { return gOptions_; }
 
-	std::string factor() const { return gFactor_; }
+	const std::string & factor() const { return gFactor_; }
 
 	friend std::ostream& operator<<(std::ostream& os, const GeometryTerm& gt)
 	{

--- a/PsimagLite/src/Geometry/GeometryTerm.h
+++ b/PsimagLite/src/Geometry/GeometryTerm.h
@@ -415,7 +415,7 @@ public:
 		return geometryBase_->calcDir(i, j);
 	}
 
-	String options() const { return gOptions_; }
+	const std::string& options() const { return gOptions_; }
 
 	std::string factor() const { return gFactor_; }
 

--- a/PsimagLite/src/InputNg.h
+++ b/PsimagLite/src/InputNg.h
@@ -1066,6 +1066,10 @@ public:
 			return buffer2;
 		}
 
+		Readable(const Readable&) = delete;
+
+		Readable& operator=(const Readable&) = delete;
+
 		// serializr start class InputNgReadable
 		// serializr normal file_
 		String file_;

--- a/PsimagLite/src/InputNg.h
+++ b/PsimagLite/src/InputNg.h
@@ -1070,6 +1070,10 @@ public:
 
 		Readable& operator=(const Readable&) = delete;
 
+		Readable(Readable&&) = delete;
+
+		Readable& operator=(Readable&&) = delete;
+
 		// serializr start class InputNgReadable
 		// serializr normal file_
 		String file_;

--- a/TestSuite/inputs/descriptions.txt
+++ b/TestSuite/inputs/descriptions.txt
@@ -426,4 +426,6 @@ d===> 0.3091
 6700) FindSymmetrySector= awesome predicate
 #7000) Chemical H: Gauge spin
 #7001-7500 reserved for ChemicalH
+9000) Peierls GS
+9001) Peierls time evolution
 #TAGEND DO NOT REMOVE THIS TAG

--- a/TestSuite/inputs/input9000.ain
+++ b/TestSuite/inputs/input9000.ain
@@ -1,0 +1,35 @@
+##Ainur1.0
+
+# We do 8 sites for now so it goes fast
+# You can change the number of sites
+# here and it should work 
+TotalNumberOfSites=4;
+NumberOfTerms=1;
+GeometryKind="chain";
+GeometryOptions="ConstantValues";
+# Nothing depends on time here 
+# because this is a g.s. run
+# and therefore time = 0
+dir0:Connectors=[1.0];
+
+OutputFile="data9000";
+
+#Model params
+hubbardU=[8.0, ...];
+potentialV=[10000000, 0, 0, 10000000, 10000000, 0, 0, 10000000];
+Model="HubbardOneBand";
+SolverOptions="twositedmrg,usecomplex";
+Version="Pierls";
+InfiniteLoopKeptStates=100;
+FiniteLoops=[[@auto, 500, 0],
+[@auto, 500, 0],
+[@auto, 500, @save]];
+
+# This is Hubbard at half filling
+#TargetElectronsUp=0.5*%n;
+#TargetElectronsDown=0.5*%n;
+
+TargetElectronsUp=1;
+TargetElectronsDown=1;
+
+

--- a/TestSuite/inputs/input9001.ain
+++ b/TestSuite/inputs/input9001.ain
@@ -1,0 +1,72 @@
+##Ainur1.0
+
+# If you change the number of sites
+# adjust also TSPSites and AdvanceEach below
+TotalNumberOfSites=4;
+
+NumberOfTerms=1;
+GeometryKind="chain";
+GeometryOptions="ConstantValues";
+dir0:Connectors=[1.0];
+
+# BEGIN time dependence block
+# This multiplies all
+# hoppings by exp(iA(time))
+
+matrix AversusTime=[
+[0.0, 0.0],
+[0.1, 0.05],
+[0.2, 0.1],
+[0.3, 0.15],
+[0.4, 0.2],
+[0.5, 0.25],
+[0.6, 0.3],
+[0.7, 0.35]
+];
+
+GeometryFactor=exp:*:1.0i:!readTable(AversusTime,%t);
+
+# END time dependence block
+
+# Model params
+hubbardU=[8.0, ...];
+potentialV=[10000000, 0, 0, 10000000, 10000000, 0, 0, 10000000];
+Model="HubbardOneBand";
+
+# We restart from the g.s. run
+# and do time evolution
+SolverOptions="twositedmrg,TimeStepTargeting,restart,usecomplex";
+Version="Pierls";
+InfiniteLoopKeptStates=100;
+FiniteLoops=[[-2, 200, 2], [2, 200, 3]];
+
+# You can add more repetitons or loops
+# here so it goes to larger and larger times
+RepeatFiniteLoopsTimes=3;
+
+# Half filling
+TargetElectronsUp=1;
+TargetElectronsDown=1;
+
+# The input9000.hd5 file
+# must have been created
+# from the input9000 run
+# and must be located
+# in this directory
+RestartFilename=data9000;
+OutputFile=data9001;
+
+# Weight of the g.s. vector in the density matrix
+# or SVD
+GsWeight=0.2;
+
+# Time evolution parameters
+TSPTau=0.1;
+TSPTimeSteps=3;
+
+# We advance after N-2 finite loops
+TSPAdvanceEach=2;
+TSPAlgorithm=Krylov;
+
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,10 @@ add_lowest_eigenvalue_check_test(output6020 -2.59474 runForinput6020.cout)
 add_test(NAME input6700 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input6700.ain) # energy -4.17889 we don't check this
 add_test(NAME input8900 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input8900.ain "<gs|sz_p|gs>") # none
 add_test(NAME input8901 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input8901.ain "<gs|sz|gs>") # none
+add_test(NAME input9000 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input9000.ain) # energy -0.472136
+add_test(NAME input9001 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input9001.ain "<P0|n|P0>"
+)# in-situ 1 (1.010966,0.000000) 0.500000 <P0|n|P0> (1.000000,0.000000)
+
 # Tests for the observe executable
 add_test(NAME observe0002 COMMAND ./observe -l "+r" -f ${PATH_TO_INPUTS}/input2.ain
                                   "<gs|c';c|gs>,<gs|2.0*sz;2.0*sz|gs>,<gs|n;n|gs>")

--- a/src/Engine/CookInputExpression.hh
+++ b/src/Engine/CookInputExpression.hh
@@ -1,0 +1,69 @@
+#ifndef COOKINPUTEXPRESSION_HH
+#define COOKINPUTEXPRESSION_HH
+#include "InputCheck.h"
+#include "InputNg.h"
+#include "Matrix.h"
+#include "PsimagLite.h"
+#include <string>
+#include <vector>
+
+namespace Dmrg {
+
+template <typename ComplexOrRealType> class CookInputExpression {
+public:
+
+	using RealType             = typename PsimagLite::Real<ComplexOrRealType>::Type;
+	using InputNgType          = PsimagLite::InputNg<Dmrg::InputCheck>;
+	using InputNgValidatorType = InputNgType::Readable;
+
+	CookInputExpression(const InputNgValidatorType& io)
+	    : io_(io)
+	{ }
+
+	std::string operator()(const std::string& expr)
+	{
+		std::string label = "!readTable";
+		if (expr.substr(0, label.size()) == label) {
+			std::string str = expr.substr(label.size(), std::string::npos);
+			// delete spaces FIXME TODO
+			// split on comma
+			std::vector<std::string> args;
+			PsimagLite::split(args, str, ",");
+			if (args.size() != 2) {
+				err("readTable expects two arguments\n");
+			}
+
+			// delete PARENS FIXME TODO
+			// delete double quotes FIXME TODO
+			PsimagLite::Matrix<RealType> matrix;
+			InputNgValidatorType& io_non_const = const_cast<InputNgValidatorType&>(io_);
+			io_non_const.read(matrix, args[0]);
+			RealType value = findValueFor(matrix, PsimagLite::atof(args[1]));
+			return ttos(value);
+		} else {
+			return expr;
+		}
+	}
+
+private:
+
+	static RealType findValueFor(const PsimagLite::Matrix<RealType>& matrix, const RealType& t)
+	{
+		SizeType rows = matrix.rows();
+		if (matrix.cols() != 2) {
+			err("findValueFor(): not a table\n");
+		}
+
+		for (SizeType i = 0; i < rows; ++i) {
+			if (matrix(i, 0) == t) {
+				return matrix(i, 1);
+			}
+		}
+
+		throw std::runtime_error("Value not found in table\n");
+	}
+
+	const InputNgValidatorType& io_;
+};
+}
+#endif // COOKINPUTEXPRESSION_HH

--- a/src/Engine/CookInputExpression.hh
+++ b/src/Engine/CookInputExpression.hh
@@ -25,7 +25,19 @@ public:
 		std::string label = "!readTable";
 		if (expr.substr(0, label.size()) == label) {
 			std::string str = expr.substr(label.size(), std::string::npos);
-			// delete spaces FIXME TODO
+
+			// delete spaces if any
+			str.erase(std::remove_if(str.begin(), str.end(), isspace), str.end());
+
+			// delete parens if any
+			SizeType length = str.length();
+			if (length > 0 && str[0] == '(' && str[length - 1] == ')') {
+				str.erase(0, 1);
+				if (length > 1) {
+					str.erase(length - 2, 1);
+				}
+			}
+
 			// split on comma
 			std::vector<std::string> args;
 			PsimagLite::split(args, str, ",");
@@ -33,8 +45,6 @@ public:
 				err("readTable expects two arguments\n");
 			}
 
-			// delete PARENS FIXME TODO
-			// delete double quotes FIXME TODO
 			PsimagLite::Matrix<RealType> matrix;
 			InputNgValidatorType& io_non_const = const_cast<InputNgValidatorType&>(io_);
 			io_non_const.read(matrix, args[0]);

--- a/src/Engine/CookInputExpression.hh
+++ b/src/Engine/CookInputExpression.hh
@@ -44,7 +44,7 @@ public:
 	 *
 	 * It keeps a reference to the input parameters.
 	 * If using Ainur the io could be const throughout. However, for the plain old input
-	 * format, the input parameter reads needs also write access due to allowing
+	 * format, the input parameter reads needs also write access due to permitting
 	 * duplicated labels. In the future we may disable support for the plain old input format.
 	 *
 	 * \param[in/out] input_params  The input object; sorry about the non-constness
@@ -63,9 +63,9 @@ public:
 	 *
 	 * \param[in] factor           The string coming from the input file entry
 	 * \param[in] value_for_empty  The value to return if factor is empty
-	 * \param[in] time             The time, whose meaning depend on the target being run
+	 * \param[in] time             The time, whose meaning depends on the target being run
 	 *
-	 * \returns The real or complex value resulting from cooking factor
+	 * \returns The real or complex value resulting from cooking the string factor
 	 */
 	ComplexOrRealType operator()(const std::string&       factor,
 	                             const ComplexOrRealType& value_for_empty,
@@ -101,6 +101,7 @@ private:
 	 * \brief If present, evaluates a function with an argument
 	 *
 	 * See input9001.ain in the TestSuite for an example.
+	 *
 	 * Here other directives could be added in the future.
 	 *
 	 * \param[in] expr The expression to check for a function or table

--- a/src/Engine/CookInputExpression.hh
+++ b/src/Engine/CookInputExpression.hh
@@ -16,7 +16,7 @@ public:
 	using InputNgType          = PsimagLite::InputNg<Dmrg::InputCheck>;
 	using InputNgValidatorType = InputNgType::Readable;
 
-	CookInputExpression(const InputNgValidatorType& io)
+	CookInputExpression(InputNgValidatorType& io)
 	    : io_(io)
 	{ }
 
@@ -46,8 +46,7 @@ public:
 			}
 
 			PsimagLite::Matrix<RealType> matrix;
-			InputNgValidatorType& io_non_const = const_cast<InputNgValidatorType&>(io_);
-			io_non_const.read(matrix, args[0]);
+			io_.read(matrix, args[0]);
 			RealType value = findValueFor(matrix, PsimagLite::atof(args[1]));
 			return ttos(value);
 		} else {
@@ -73,7 +72,7 @@ private:
 		throw std::runtime_error("Value not found in table\n");
 	}
 
-	const InputNgValidatorType& io_;
+	InputNgValidatorType& io_;
 };
 }
 #endif // COOKINPUTEXPRESSION_HH

--- a/src/Engine/CookInputExpression.hh
+++ b/src/Engine/CookInputExpression.hh
@@ -1,5 +1,15 @@
+//---------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   src/Engine/CookInputExpression.hh
+ * \brief  Process input expressions
+ * \note   Copyright (c) 2026 Oak Ridge National Laboratory, UT-Battelle, LLC.
+ */
+//---------------------------------------------------------------------------//
+
 #ifndef COOKINPUTEXPRESSION_HH
 #define COOKINPUTEXPRESSION_HH
+#include "AST/ExpressionForAST.h"
+#include "AST/PlusMinusMultiplyDivide.h"
 #include "InputCheck.h"
 #include "InputNg.h"
 #include "Matrix.h"
@@ -8,6 +18,18 @@
 #include <vector>
 
 namespace Dmrg {
+//===========================================================================//
+/*!
+ * \class CookInputExpression
+ *
+ * \brief Process input expressions including replacements and tables
+ *
+ * In the future, this class will be used in more places to allow for user
+ * more complicated user input.
+ *
+ * \tparam ComplexOrRealType The type of numbers whether real or complex
+ */
+//===========================================================================//
 
 template <typename ComplexOrRealType> class CookInputExpression {
 public:
@@ -16,11 +38,76 @@ public:
 	using InputNgType          = PsimagLite::InputNg<Dmrg::InputCheck>;
 	using InputNgValidatorType = InputNgType::Readable;
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Constructor
+	 *
+	 * It keeps a reference to the input parameters.
+	 * If using Ainur the io could be const throughout. However, for the plain old input
+	 * format, the input parameter reads needs also write access due to allowing
+	 * duplicated labels. In the future we may disable support for the plain old input format.
+	 *
+	 * \param[in/out] input_params  The input object; sorry about the non-constness
+	 */
 	CookInputExpression(InputNgValidatorType& io)
 	    : io_(io)
 	{ }
 
-	std::string operator()(const std::string& expr)
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Operator parens
+	 *
+	 * Convert an input string into a complex number, after replacements, and
+	 * expression processing. We are using the AST class for expressions here.
+	 * For example, the string "+:3:4" would return 7.
+	 *
+	 * \param[in] factor           The string coming from the input file entry
+	 * \param[in] value_for_empty  The value to return if factor is empty
+	 * \param[in] time             The time, whose meaning depend on the target being run
+	 *
+	 * \returns The real or complex value resulting from cooking factor
+	 */
+	ComplexOrRealType operator()(const std::string&       factor,
+	                             const ComplexOrRealType& value_for_empty,
+	                             const RealType&          time) const
+	{
+		if (factor.empty())
+			return value_for_empty;
+
+		SizeType number_of_sites = 0;
+		io_.readline(number_of_sites, "TotalNumberOfSites=");
+
+		std::string str = factor;
+		PsimagLite::replaceAll(str, "%t", ttos(time));
+		PsimagLite::replaceAll(str, "%n", ttos(number_of_sites));
+
+		std::vector<std::string> ve;
+		PsimagLite::split(ve, str, ":");
+
+		for (SizeType i = 0; i < ve.size(); ++i) {
+			ve[i] = replaceTables(ve[i]);
+		}
+
+		typedef PsimagLite::PlusMinusMultiplyDivide<ComplexOrRealType> PrimitivesType;
+		PrimitivesType                                                 primitives;
+		PsimagLite::ExpressionForAST<PrimitivesType> expresionForAST(ve, primitives);
+		return expresionForAST.exec();
+	}
+
+private:
+
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief If present, evaluates a function with an argument
+	 *
+	 * See input9001.ain in the TestSuite for an example.
+	 * Here other directives could be added in the future.
+	 *
+	 * \param[in] expr The expression to check for a function or table
+	 *
+	 * \returns The value of the function at the argument, or the expression unchanged
+	 */
+	std::string replaceTables(const std::string& expr) const
 	{
 		std::string label = "!readTable";
 		if (expr.substr(0, label.size()) == label) {
@@ -54,8 +141,18 @@ public:
 		}
 	}
 
-private:
-
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Evaluate a function (given as a matrix) at a point
+	 *
+	 * See input9001.ain in the TestSuite for an example.
+	 * Here other directives could be added in the future.
+	 *
+	 * \param[in] matrix The matrix that represents the function
+	 * \param[in] t      The argument to the function (first column of the matrix)
+	 *
+	 * \returns The value of the function at t
+	 */
 	static RealType findValueFor(const PsimagLite::Matrix<RealType>& matrix, const RealType& t)
 	{
 		SizeType rows = matrix.rows();
@@ -72,6 +169,7 @@ private:
 		throw std::runtime_error("Value not found in table\n");
 	}
 
+	// The input params object
 	InputNgValidatorType& io_;
 };
 }

--- a/src/Engine/CorrectionVectorSkeleton.h
+++ b/src/Engine/CorrectionVectorSkeleton.h
@@ -270,7 +270,7 @@ private:
 		const RealType                                fakeTime = 0;
 		typename ModelHelperType::Aux                 aux(p, lrs_);
 		typename ModelType::HamiltonianConnectionType hc(
-		    lrs_, ModelType::modelLinks(), fakeTime, model_.superOpHelper());
+		    lrs_, ModelType::modelLinks(), fakeTime, model_.superOpHelper(), ioIn_);
 		LanczosMatrixType            h(model_, hc, aux);
 		RealType                     E0 = energy_;
 		CorrectionVectorFunctionType cvft(h, tstStruct_, E0);

--- a/src/Engine/Diagonalization.h
+++ b/src/Engine/Diagonalization.h
@@ -541,7 +541,7 @@ private:
 		const OptionsType& options = parameters_.options;
 
 		HamiltonianConnectionType hc(
-		    lrs, ModelType::modelLinks(), targetTime, model_.superOpHelper());
+		    lrs, ModelType::modelLinks(), targetTime, model_.superOpHelper(), io_);
 
 		bool only_slow_wft = false;
 		if (inf_or_finite.isFinite()) {

--- a/src/Engine/HamiltonianAbstract.h
+++ b/src/Engine/HamiltonianAbstract.h
@@ -55,8 +55,8 @@ public:
 	{
 		ComplexOrRealType value
 		    = superGeometry_(smax_, emin_, hItems, oneLink.orbs, termIndexForGeom);
-		SizeType site = findSite(hItems);
-		oneLink.modifier(value, targetTime, site);
+		// SizeType site = findSite(hItems);
+		oneLink.modifier(value, targetTime, hItems);
 		return value;
 	}
 
@@ -73,15 +73,6 @@ public:
 	const SuperGeometryType& superGeometry() const { return superGeometry_; }
 
 private:
-
-	SizeType findSite(const VectorSizeType& hItems) const
-	{
-		ProgramGlobals::ConnectionEnum type = superGeometry_.connectionKind(smax_, hItems);
-		assert(type == ProgramGlobals::ConnectionEnum::SYSTEM_ENVIRON
-		       || type == ProgramGlobals::ConnectionEnum::ENVIRON_SYSTEM);
-		return (type == ProgramGlobals::ConnectionEnum::SYSTEM_ENVIRON) ? hItems[0]
-		                                                                : hItems[1];
-	}
 
 	const SuperGeometryType& superGeometry_;
 	const SizeType           smax_;

--- a/src/Engine/HamiltonianAbstract.h
+++ b/src/Engine/HamiltonianAbstract.h
@@ -55,7 +55,6 @@ public:
 	{
 		ComplexOrRealType value
 		    = superGeometry_(smax_, emin_, hItems, oneLink.orbs, termIndexForGeom);
-		// SizeType site = findSite(hItems);
 		oneLink.modifier(value, targetTime, hItems);
 		return value;
 	}

--- a/src/Engine/HamiltonianConnection.h
+++ b/src/Engine/HamiltonianConnection.h
@@ -77,7 +77,10 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #ifndef HAMILTONIAN_CONNECTION_H
 #define HAMILTONIAN_CONNECTION_H
 
+#include "AST/ExpressionForAST.h"
+#include "AST/PlusMinusMultiplyDivide.h"
 #include "Concurrency.h"
+#include "CookInputExpression.hh"
 #include "CrsMatrix.h"
 #include "HamiltonianAbstract.h"
 #include "ManyToTwoConnection.h"
@@ -122,15 +125,17 @@ public:
 	using SuperOpHelperBaseType   = SuperOpHelperBase<SuperGeometryType, ParamsForSolverType>;
 	using ManyToTwoConnectionType
 	    = ManyToTwoConnection<ModelLinksType, LeftRightSuperType, SuperOpHelperBaseType>;
-	using OpsForLinkType = OpsForLink<LeftRightSuperType>;
+	using OpsForLinkType          = OpsForLink<LeftRightSuperType>;
+	using CookInputExpressionType = CookInputExpression<ComplexOrRealType>;
+	using InputNgType             = typename CookInputExpressionType::InputNgType;
 
-	HamiltonianConnection(const LeftRightSuperType&    lrs,
-	                      const ModelLinksType&        lpb,
-	                      RealType                     targetTime,
-	                      const SuperOpHelperBaseType& superOpHelper)
+	HamiltonianConnection(const LeftRightSuperType&             lrs,
+	                      const ModelLinksType&                 lpb,
+	                      RealType                              time,
+	                      const SuperOpHelperBaseType&          superOpHelper,
+	                      const typename InputNgType::Readable& io)
 	    : modelHelper_(lrs)
 	    , modelLinks_(lpb)
-	    , targetTime_(targetTime)
 	    , superOpHelper_(superOpHelper)
 	    , operatorsCached_(lrs)
 	    , progress_("HamiltonianConnection")
@@ -149,7 +154,7 @@ public:
 		lps_.reserve(ProgramGlobals::MAX_LPS);
 		SizeType nitems = hamAbstract_.items();
 		for (SizeType x = 0; x < nitems; ++x)
-			totalOnes_[x] = cacheConnections(x);
+			totalOnes_[x] = cacheConnections(x, time, io);
 
 		SizeType last = lrs.super().block().size();
 		assert(last > 0);
@@ -268,7 +273,8 @@ public:
 
 private:
 
-	SizeType cacheConnections(SizeType x)
+	SizeType
+	cacheConnections(SizeType x, const RealType& time, const typename InputNgType::Readable& io)
 	{
 		const VectorSizeType& hItems = hamAbstract_.item(x);
 
@@ -299,11 +305,24 @@ private:
 
 				const OneLink<ComplexOrRealType>& oneLink = term(dofs);
 
-				ComplexOrRealType tmp = hamAbstract_.connectionValue(
-				    hItems, oneLink, termIndexForGeom, targetTime_);
+				ComplexOrRealType tmp1 = hamAbstract_.connectionValue(
+				    hItems, oneLink, termIndexForGeom, time);
 
-				if (tmp == static_cast<RealType>(0.0))
+				if (tmp1 == 0.0)
 					continue;
+
+				// Factor added in the input file for this geometry term
+				const std::string& geometry_factor = hamAbstract_.superGeometry()
+				                                         .geometry()
+				                                         .term(termIndex)
+				                                         .factor();
+				ComplexOrRealType tmp2
+				    = geometryFactor(geometry_factor, time, hItems, io);
+
+				if (tmp2 == 0.0)
+					continue;
+
+				ComplexOrRealType tmp = tmp1 * tmp2;
 
 				ManyToTwoConnectionType manyToTwo(hItems,
 				                                  type,
@@ -352,6 +371,32 @@ private:
 
 		lps_.push_back(link2);
 		return 1;
+	}
+
+	static ComplexOrRealType geometryFactor(const std::string& factor,
+	                                        const RealType&    time,
+	                                        const std::vector<SizeType>&,
+	                                        const typename InputNgType::Readable& io)
+	{
+		if (factor.empty())
+			return 1.0;
+
+		std::string str = factor;
+		PsimagLite::replaceAll(str, "%t", ttos(time));
+		// TODO FIXME replace also number of sites here
+
+		std::vector<std::string> ve;
+		PsimagLite::split(ve, str, ":");
+
+		CookInputExpression<ComplexOrRealType> cook_input_expression(io);
+		for (SizeType i = 0; i < ve.size(); ++i) {
+			ve[i] = cook_input_expression(ve[i]);
+		}
+
+		typedef PsimagLite::PlusMinusMultiplyDivide<ComplexOrRealType> PrimitivesType;
+		PrimitivesType                                                 primitives;
+		PsimagLite::ExpressionForAST<PrimitivesType> expresionForAST(ve, primitives);
+		return expresionForAST.exec();
 	}
 
 	void checkGeometryTerms() const
@@ -420,7 +465,6 @@ private:
 
 	const ModelHelperType         modelHelper_;
 	const ModelLinksType&         modelLinks_;
-	RealType                      targetTime_;
 	const SuperOpHelperBaseType&  superOpHelper_;
 	OperatorsCachedType           operatorsCached_;
 	PsimagLite::ProgressIndicator progress_;

--- a/src/Engine/HamiltonianConnection.h
+++ b/src/Engine/HamiltonianConnection.h
@@ -373,17 +373,18 @@ private:
 		return 1;
 	}
 
-	static ComplexOrRealType geometryFactor(const std::string& factor,
-	                                        const RealType&    time,
-	                                        const std::vector<SizeType>&,
-	                                        const typename InputNgType::Readable& io)
+	ComplexOrRealType geometryFactor(const std::string& factor,
+	                                 const RealType&    time,
+	                                 const std::vector<SizeType>&,
+	                                 const typename InputNgType::Readable& io) const
 	{
 		if (factor.empty())
 			return 1.0;
 
-		std::string str = factor;
+		SizeType    number_of_sites = hamAbstract_.superGeometry().numberOfSites();
+		std::string str             = factor;
 		PsimagLite::replaceAll(str, "%t", ttos(time));
-		// TODO FIXME replace also number of sites here
+		PsimagLite::replaceAll(str, "%n", ttos(number_of_sites));
 
 		std::vector<std::string> ve;
 		PsimagLite::split(ve, str, ":");

--- a/src/Engine/HamiltonianConnection.h
+++ b/src/Engine/HamiltonianConnection.h
@@ -129,11 +129,11 @@ public:
 	using CookInputExpressionType = CookInputExpression<ComplexOrRealType>;
 	using InputNgType             = typename CookInputExpressionType::InputNgType;
 
-	HamiltonianConnection(const LeftRightSuperType&             lrs,
-	                      const ModelLinksType&                 lpb,
-	                      RealType                              time,
-	                      const SuperOpHelperBaseType&          superOpHelper,
-	                      const typename InputNgType::Readable& io)
+	HamiltonianConnection(const LeftRightSuperType&       lrs,
+	                      const ModelLinksType&           lpb,
+	                      RealType                        time,
+	                      const SuperOpHelperBaseType&    superOpHelper,
+	                      typename InputNgType::Readable& io)
 	    : modelHelper_(lrs)
 	    , modelLinks_(lpb)
 	    , superOpHelper_(superOpHelper)
@@ -274,7 +274,7 @@ public:
 private:
 
 	SizeType
-	cacheConnections(SizeType x, const RealType& time, const typename InputNgType::Readable& io)
+	cacheConnections(SizeType x, const RealType& time, typename InputNgType::Readable& io)
 	{
 		const VectorSizeType& hItems = hamAbstract_.item(x);
 
@@ -376,7 +376,7 @@ private:
 	ComplexOrRealType geometryFactor(const std::string& factor,
 	                                 const RealType&    time,
 	                                 const std::vector<SizeType>&,
-	                                 const typename InputNgType::Readable& io) const
+	                                 typename InputNgType::Readable& io) const
 	{
 		if (factor.empty())
 			return 1.0;

--- a/src/Engine/HamiltonianConnection.h
+++ b/src/Engine/HamiltonianConnection.h
@@ -77,8 +77,6 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #ifndef HAMILTONIAN_CONNECTION_H
 #define HAMILTONIAN_CONNECTION_H
 
-#include "AST/ExpressionForAST.h"
-#include "AST/PlusMinusMultiplyDivide.h"
 #include "Concurrency.h"
 #include "CookInputExpression.hh"
 #include "CrsMatrix.h"
@@ -289,6 +287,8 @@ private:
 		assert(type != ProgramGlobals::ConnectionEnum::SYSTEM_SYSTEM
 		       && type != ProgramGlobals::ConnectionEnum::ENVIRON_ENVIRON);
 
+		CookInputExpressionType cook_input_expression(io);
+
 		SizeType       totalOne      = 0;
 		const SizeType geometryTerms = modelLinks_.numberOfTerms();
 		for (SizeType termIndex = 0; termIndex < geometryTerms; ++termIndex) {
@@ -316,8 +316,10 @@ private:
 				                                         .geometry()
 				                                         .term(termIndex)
 				                                         .factor();
+
+				// default_value = 1.0, that is, if factor is not present
 				ComplexOrRealType tmp2
-				    = geometryFactor(geometry_factor, time, hItems, io);
+				    = cook_input_expression(geometry_factor, 1.0, time);
 
 				if (tmp2 == 0.0)
 					continue;
@@ -371,33 +373,6 @@ private:
 
 		lps_.push_back(link2);
 		return 1;
-	}
-
-	ComplexOrRealType geometryFactor(const std::string& factor,
-	                                 const RealType&    time,
-	                                 const std::vector<SizeType>&,
-	                                 typename InputNgType::Readable& io) const
-	{
-		if (factor.empty())
-			return 1.0;
-
-		SizeType    number_of_sites = hamAbstract_.superGeometry().numberOfSites();
-		std::string str             = factor;
-		PsimagLite::replaceAll(str, "%t", ttos(time));
-		PsimagLite::replaceAll(str, "%n", ttos(number_of_sites));
-
-		std::vector<std::string> ve;
-		PsimagLite::split(ve, str, ":");
-
-		CookInputExpression<ComplexOrRealType> cook_input_expression(io);
-		for (SizeType i = 0; i < ve.size(); ++i) {
-			ve[i] = cook_input_expression(ve[i]);
-		}
-
-		typedef PsimagLite::PlusMinusMultiplyDivide<ComplexOrRealType> PrimitivesType;
-		PrimitivesType                                                 primitives;
-		PsimagLite::ExpressionForAST<PrimitivesType> expresionForAST(ve, primitives);
-		return expresionForAST.exec();
 	}
 
 	void checkGeometryTerms() const

--- a/src/Engine/ModelBase.h
+++ b/src/Engine/ModelBase.h
@@ -439,7 +439,7 @@ for (SizeType dof = 0; dof < numberOfDofs; ++dof) {
 		typename PsimagLite::Vector<VerySparseMatrixType*>::Type vvsm(total, 0);
 		VectorSizeType                                           nzs(total, 0);
 
-		HamiltonianConnectionType hc(lrs, modelLinks_, currentTime, superOpHelper());
+		HamiltonianConnectionType hc(lrs, modelLinks_, currentTime, superOpHelper(), ioIn_);
 
 		for (SizeType m = 0; m < total; ++m) {
 			SizeType offset = lrs.super().partition(m);

--- a/src/Engine/ModelLinks.h
+++ b/src/Engine/ModelLinks.h
@@ -106,7 +106,7 @@ public:
 			    mod1,
 			    op2,
 			    mod2,
-			    [](ComplexOrRealType&, RealType, SizeType) { },
+			    [](ComplexOrRealType&, RealType, std::vector<SizeType>) { },
 			    su2properties);
 		}
 
@@ -130,7 +130,7 @@ public:
 		          OldLambdaType   modifier)
 		{
 			LambdaType newModif
-			    = [modifier](ComplexOrRealType& value, RealType, SizeType)
+			    = [modifier](ComplexOrRealType& value, RealType, std::vector<SizeType>)
 			{ modifier(value); };
 			push(op1, mod1, op2, mod2, newModif, Su2Properties());
 		}
@@ -144,7 +144,7 @@ public:
 			    mod1,
 			    op2,
 			    mod2,
-			    [](ComplexOrRealType&, RealType, SizeType) { },
+			    [](ComplexOrRealType&, RealType, std::vector<SizeType>) { },
 			    Su2Properties());
 		}
 

--- a/src/Engine/OneLink.hh
+++ b/src/Engine/OneLink.hh
@@ -9,9 +9,9 @@ template <typename ComplexOrRealType> class OneLink {
 
 public:
 
-	using RealType       = typename PsimagLite::Real<ComplexOrRealType>::Type;
-	using OldLambdaType  = std::function<void(ComplexOrRealType&)>;
-	using LambdaType     = std::function<void(ComplexOrRealType&, RealType, SizeType)>;
+	using RealType      = typename PsimagLite::Real<ComplexOrRealType>::Type;
+	using OldLambdaType = std::function<void(ComplexOrRealType&)>;
+	using LambdaType = std::function<void(ComplexOrRealType&, RealType, std::vector<SizeType>)>;
 	using VectorSizeType = std::vector<SizeType>;
 
 	OneLink(VectorSizeType                     indices_,
@@ -48,7 +48,7 @@ public:
 	    , angularFactor(angularFactor_)
 	    , category(category_)
 	{
-		modifier = [vModifier_](ComplexOrRealType& value, RealType, SizeType)
+		modifier = [vModifier_](ComplexOrRealType& value, RealType, std::vector<SizeType>)
 		{ vModifier_(value); };
 	}
 

--- a/src/Engine/ParallelTriDiag.h
+++ b/src/Engine/ParallelTriDiag.h
@@ -136,9 +136,12 @@ private:
 	{
 		const SizeType                p = lrs_.super().findPartitionNumber(phi.offset(i0));
 		typename ModelHelperType::Aux aux(p, lrs_);
-		typename ModelType::HamiltonianConnectionType hc(
-		    lrs_, ModelType::modelLinks(), currentTime_, model_.superOpHelper());
-		typename LanczosSolverType::MatrixType lanczosHelper(model_, hc, aux);
+		typename ModelType::HamiltonianConnectionType hc(lrs_,
+		                                                 ModelType::modelLinks(),
+		                                                 currentTime_,
+		                                                 model_.superOpHelper(),
+		                                                 model_.ioIn());
+		typename LanczosSolverType::MatrixType        lanczosHelper(model_, hc, aux);
 
 		typename LanczosSolverType::ParametersSolverType params(io_, "Tridiag");
 		params.lotaMemory = true;

--- a/src/Engine/TargetingDynamic.h
+++ b/src/Engine/TargetingDynamic.h
@@ -286,7 +286,8 @@ private:
 		typename ModelType::HamiltonianConnectionType hc(BaseType::lrs(),
 		                                                 ModelType::modelLinks(),
 		                                                 fakeTime,
-		                                                 BaseType::model().superOpHelper());
+		                                                 BaseType::model().superOpHelper(),
+		                                                 BaseType::model().ioIn());
 		typename LanczosSolverType::MatrixType        h(BaseType::model(), hc, aux);
 		paramsForSolver_.lotaMemory = true;
 		LanczosSolverType lanczosSolver(h, paramsForSolver_);

--- a/src/Engine/TargetingMetts.h
+++ b/src/Engine/TargetingMetts.h
@@ -811,7 +811,8 @@ private:
 		    BaseType::lrs(),
 		    BaseType::ModelType::modelLinks(),
 		    this->common().aoe().timeVectors().time(),
-		    model_.superOpHelper());
+		    model_.superOpHelper(),
+		    model_.ioIn());
 		typename LanczosSolverType::MatrixType lanczosHelper(BaseType::model(), hc, aux);
 
 		SizeType         total = phi.effectiveSize(i0);

--- a/src/Engine/TargetingTimeStep.h
+++ b/src/Engine/TargetingTimeStep.h
@@ -349,7 +349,8 @@ private:
 		    BaseType::lrs(),
 		    ModelType::modelLinks(),
 		    this->common().aoe().timeVectors().time(),
-		    BaseType::model().superOpHelper());
+		    BaseType::model().superOpHelper(),
+		    BaseType::model().ioIn());
 		typename LanczosSolverType::MatrixType lanczosHelper(BaseType::model(), hc, aux);
 
 		const SizeType   total = phi.effectiveSize(i0);

--- a/src/Engine/TimeVectorsChebyshev.h
+++ b/src/Engine/TimeVectorsChebyshev.h
@@ -316,9 +316,12 @@ private:
 	{
 		SizeType                      p = lrs_.super().findPartitionNumber(phi.offset(i0));
 		typename ModelHelperType::Aux aux(p, lrs_);
-		typename ModelType::HamiltonianConnectionType hc(
-		    lrs_, ModelType::modelLinks(), this->time(), model_.superOpHelper());
-		MatrixLanczosType lanczosHelper(model_, hc, aux);
+		typename ModelType::HamiltonianConnectionType hc(lrs_,
+		                                                 ModelType::modelLinks(),
+		                                                 this->time(),
+		                                                 model_.superOpHelper(),
+		                                                 model_.ioIn());
+		MatrixLanczosType                             lanczosHelper(model_, hc, aux);
 
 		ProgramGlobals::VerboseEnum verbose
 		    = (model_.params().options.isSet("VerboseCheby"))
@@ -483,10 +486,13 @@ private:
 	{
 		const SizeType                p = lrs_.super().findPartitionNumber(phi.offset(i0));
 		typename ModelHelperType::Aux aux(p, lrs_);
-		typename ModelType::HamiltonianConnectionType hc(
-		    lrs_, ModelType::modelLinks(), currentTime, model_.superOpHelper());
-		MatrixLanczosType           lanczosHelper(model_, hc, aux);
-		ProgramGlobals::VerboseEnum verbose
+		typename ModelType::HamiltonianConnectionType hc(lrs_,
+		                                                 ModelType::modelLinks(),
+		                                                 currentTime,
+		                                                 model_.superOpHelper(),
+		                                                 model_.ioIn());
+		MatrixLanczosType                             lanczosHelper(model_, hc, aux);
+		ProgramGlobals::VerboseEnum                   verbose
 		    = (model_.params().options.isSet("VerboseCheby"))
 		    ? ProgramGlobals::VerboseEnum::YES
 		    : ProgramGlobals::VerboseEnum::NO;

--- a/src/Engine/TimeVectorsRungeKutta.h
+++ b/src/Engine/TimeVectorsRungeKutta.h
@@ -180,7 +180,11 @@ private:
 		    , timeDirection_(timeDirection)
 		    , p_(lrs.super().findPartitionNumber(phi.offset(i0)))
 		    , aux_(p_, lrs)
-		    , hc_(lrs, ModelType::modelLinks(), currentTime, model.superOpHelper())
+		    , hc_(lrs,
+		          ModelType::modelLinks(),
+		          currentTime,
+		          model.superOpHelper(),
+		          model.ioIn())
 		    , lanczosHelper_(model, hc_, aux_)
 		{ }
 

--- a/src/Models/HubbardOneBand/ParametersModelHubbard.h
+++ b/src/Models/HubbardOneBand/ParametersModelHubbard.h
@@ -123,14 +123,6 @@ struct ParametersModelHubbard : public ParametersModelBase<RealType, QnType> {
 			magneticX.clear();
 		}
 
-		try {
-			potentialA.resize(nsites, 0.0);
-			io.read(potentialA, "PotentialA");
-			std::cout << "Has PotentialA\n";
-		} catch (std::exception&) {
-			potentialA.clear();
-		}
-
 		if (magneticX.size() > 0 && magneticX.size() != nsites) {
 			throw PsimagLite::RuntimeError("MagneticFieldX size must be " + ttos(nsites)
 			                               + " entries long, if provided.\n");
@@ -193,7 +185,6 @@ struct ParametersModelHubbard : public ParametersModelBase<RealType, QnType> {
 	VectorRealType potentialV;
 	VectorRealType anisotropy;
 	VectorRealType magneticX;
-	VectorRealType potentialA;
 
 	// for time-dependent H:
 	VectorStringType onSiteHaddLegacy;

--- a/src/Models/IsingMultiOrb/ModelIsingMultiOrb.h
+++ b/src/Models/IsingMultiOrb/ModelIsingMultiOrb.h
@@ -434,7 +434,8 @@ private:
 		const SizeType orbitals = modelParameters_.orbitals;
 		ModelTermType& szsz     = ModelBaseType::createTerm("szsz");
 
-		auto mylambda = [this](ComplexOrRealType& coupling, RealType time, SizeType)
+		auto mylambda
+		    = [this](ComplexOrRealType& coupling, RealType time, std::vector<SizeType>)
 		{ coupling = timeDependentConnection(coupling, time, 2); };
 
 		for (SizeType orb1 = 0; orb1 < orbitals; ++orb1) {

--- a/src/Models/SuperExtendedHubbard1Orb/SuperExtendedHubbard1Orb.h
+++ b/src/Models/SuperExtendedHubbard1Orb/SuperExtendedHubbard1Orb.h
@@ -225,7 +225,7 @@ protected:
 		    'N',
 		    splus,
 		    'C',
-		    [isSu2](SparseElementType& value, RealType, SizeType)
+		    [isSu2](SparseElementType& value, RealType, std::vector<SizeType>)
 		    { value *= (isSu2) ? -0.5 : 0.5; },
 		    typename ModelTermType::Su2Properties(2, -1, 2));
 


### PR DESCRIPTION
This PR implements time-dependent connections. For example, for a tight-binding or Hubbard model one could have
```
\sum_{i,j} exp(i*A*t) hop_{i,j} c^\dagger_i c_j + U niup nidown
```
where t in exp(iAt) is physical time.

The time dependence is implemented as a multiplicative factor on top of the regular geometry: GeometryFactor label in the input for that particular connection. This implementation is then model-independent. If the value of A in the above were constant and equal to 42.0 then one could write
```
GeometryFactor=exp:*:1.0i:*:42.0:%t
 ```
Here we use ASTs with colon ```:``` as separator. In the future we could use what I call "canonical expressions," [1] which looks more like normal algebra, or "general expressions" [2] that look almost like normal algebra.
[1] Sort of implemented; [2] not implemented yet: we would here have nested parens; for either see https://github.com/g1257/dmrgpp/blob/master/doc/DmrgPlusPlusFp1.tex

In practive it's better to use a table of value to implement a function ```A(t),``` which is shown in input9001.

If the Hamiltonian has more than one connection (say hoppings and ninj term) as in
```
\sum_{i,j} exp(i*A*t) hop_{i,j} c^\dagger_i c_j + V(t) C(i, j) n_i n_j 
```
then the label ```GeometryFactor``` must be prepended by ``gt`` followed by the index for the "geometry" or connection it belongs to:
```
gt0:GeometryFactor= this would be for the hopping term
gt1:GeometryFactor= this would be for the ninj term or V(t)
```

If GeometryFactor isn't present for a given Hamiltonian connection ("geometry" in DMRG++ jargon) then it is assumed to be 1.0.

Closes https://github.com/g1257/dmrgpp/issues/119