### PR TITLE
Fix stack-buffer-overflow reported by the address sanitizer

### DIFF
--- a/src/Models/LiouvillianHeisenberg/LiouvillianHeisenberg.hh
+++ b/src/Models/LiouvillianHeisenberg/LiouvillianHeisenberg.hh
@@ -325,8 +325,8 @@ private:
 		ModelTermType& spsm = ModelBaseType::createTerm(connection_name);
 		OpForLinkType  splus(op_name);
 
-		auto valueModiferTerm0 = [&factor = std::as_const(factor)](ComplexOrRealType& value)
-		{ value *= (0.5 * factor); };
+		auto valueModiferTerm0
+		    = [factor](ComplexOrRealType& value) { value *= (0.5 * factor); };
 		spsm.push(splus, 'N', splus, 'C', valueModiferTerm0);
 	}
 
@@ -337,8 +337,7 @@ private:
 		ModelTermType& szsz = ModelBaseType::createTerm(connection_name);
 
 		OpForLinkType sz(op_name);
-		auto valueModiferTerm0 = [&factor = std::as_const(factor)](ComplexOrRealType& value)
-		{ value *= factor; };
+		auto valueModiferTerm0 = [factor](ComplexOrRealType& value) { value *= factor; };
 		szsz.push(sz, 'N', sz, 'N', valueModiferTerm0);
 	}
 


### PR DESCRIPTION
The issue was caused by capturing a local parameter by reference in a lambda that was later executed outside its scope.