### PR TITLE
Eliminate remaining warnings in test input2

### DIFF
--- a/src/Engine/Qn.h
+++ b/src/Engine/Qn.h
@@ -1,6 +1,8 @@
 #ifndef QN_H
 #define QN_H
+
 #include "Array.h"
+#include "HDF5DisableExceptionPrinting.h"
 #include "Io/IoNg.h"
 #include "Profiling.h"
 #include "ProgramGlobals.h"
@@ -120,6 +122,7 @@ public:
 	           = PsimagLite::IoNgSerializer::NO_OVERWRITE) const
 	{
 		try {
+			HDF5DisableExceptionPrinting disable;
 			io.read(modalStruct, "modalStruct");
 		} catch (...) {
 			io.write("modalStruct", modalStruct);

--- a/src/Engine/TargetingCommon.h
+++ b/src/Engine/TargetingCommon.h
@@ -274,15 +274,16 @@ public:
 	{
 		read(io, prefix);
 
-		TimeSerializerType* ts = 0;
-
-		try {
-			ts = new TimeSerializerType(io, prefix);
-		} catch (...) {
+		if (auto& s = io.serializer(); !s.doesGroupExist(prefix + "/TimeSerializer/")) {
+			std::cerr << "WARNING: Group Def/" << prefix
+			          << "/TimeSerializer/ was not found in file " << s.filename()
+			          << ".\n Data was not read.\n";
 			return;
 		}
 
-		const typename TimeSerializerType::VectorStageEnumType& stages = ts->stages();
+		TimeSerializerType ts(io, prefix);
+
+		const typename TimeSerializerType::VectorStageEnumType& stages = ts.stages();
 		const SizeType rstages = stages.size(); // read stages
 		const SizeType dstages = aoe_.stages().size(); // destination stages
 
@@ -297,7 +298,7 @@ public:
 		for (SizeType i = 0; i < dstagesOrZero; ++i)
 			aoe_.setStage(i, stages[i]);
 
-		SizeType rtvs = ts->numberOfVectors(); // read tvs
+		SizeType rtvs = ts.numberOfVectors(); // read tvs
 		SizeType dtvs = aoe_.tvs(); // destination tvs
 
 		int tvForPsi = checkpoint.sourceTvForPsi();
@@ -310,7 +311,7 @@ public:
 			std::cout << "FIXME TODO WARNING: Need better spec for TvForPsi\n";
 			std::cerr << "FIXME TODO WARNING: Need better spec for TvForPsi\n";
 
-			aoe_.setOnlyOnePsi(ts->vector(tvForPsiUnsigned));
+			aoe_.setOnlyOnePsi(ts.vector(tvForPsiUnsigned));
 		}
 
 		ApplyOperatorExpressionType& aoeNonConst
@@ -325,18 +326,15 @@ public:
 				    + " >= " + ttos(rtvs) + "\n");
 			}
 
-			aoeNonConst.targetVectorsNonConst(i) = ts->vector(j);
+			aoeNonConst.targetVectorsNonConst(i) = ts.vector(j);
 		}
 
-		bool     sameNgst  = isThisNgstSameAsPrevious(name, ts->name(), dtvs, rtvs);
-		SizeType cTimeStep = (sameNgst) ? ts->currentTimeStep() : 0;
+		bool     sameNgst  = isThisNgstSameAsPrevious(name, ts.name(), dtvs, rtvs);
+		SizeType cTimeStep = (sameNgst) ? ts.currentTimeStep() : 0;
 		setCurrentTimeStep(cTimeStep);
 
-		RealType timeReal = (sameNgst) ? ts->time() : 0;
+		RealType timeReal = (sameNgst) ? ts.time() : 0;
 		setCurrentTime(timeReal);
-
-		delete ts;
-		ts = 0;
 	}
 
 	// END read/write


### PR DESCRIPTION
I check for the group `Def/TimeSerializer` and if it is not present I print a warning and return.

@g1257  is that better than the warning from the existing try/catch? Does something different need to happen [here](https://github.com/g1257/dmrgpp/blob/0d453cdaa6adb41b4c25604b5d63b883eec8586d/src/Engine/DmrgSolver.h#L243)?

I also suppressed another HDF5 warning inside a try/catch block.

This fixes #147.