### PR TITLE
Fix PsimagLite Version.h header include in LanczosPlusPlus

### DIFF
--- a/LanczosPlusPlus/src/Engine/LanczosDriver.h
+++ b/LanczosPlusPlus/src/Engine/LanczosDriver.h
@@ -1,6 +1,6 @@
 #ifndef LANCZOSDRIVER_H
 #define LANCZOSDRIVER_H
-#include "../../../dmrgpp/PsimagLite/src/Version.h"
+#include "../../PsimagLite/src/Version.h"
 #include "../Version.h"
 #include "AllocatorCpu.h"
 #include "PsimagLite.h"


### PR DESCRIPTION
See #133
We introduced more bad relative include path.  This one must be fixed because it prevents packaging with Spack