### PR TITLE
Fixup C standard library header includes

### DIFF
--- a/PsimagLite/src/Limit.h
+++ b/PsimagLite/src/Limit.h
@@ -1,8 +1,8 @@
 #ifndef PSIMAGLITE_LIMIT_H
 #define PSIMAGLITE_LIMIT_H
 #include "Vector.h"
+#include <cstring>
 #include <errno.h>
-#include <string.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <utility>

--- a/PsimagLite/src/MemResolv.h
+++ b/PsimagLite/src/MemResolv.h
@@ -5,9 +5,9 @@
 #include "Sort.h"
 #include "Vector.h"
 #include <cassert>
+#include <cstring>
 #include <fstream>
 #include <iostream>
-#include <string.h>
 
 namespace PsimagLite {
 

--- a/PsimagLite/src/Parallelizer2Pthread.h
+++ b/PsimagLite/src/Parallelizer2Pthread.h
@@ -19,8 +19,8 @@
 #define _GNU_SOURCE
 #endif
 #ifdef _GNU_SOURCE
+#include <cstring>
 #include <errno.h>
-#include <string.h>
 #endif
 
 template <typename SomeLambdaType, typename LoadBalancerType = PsimagLite::LoadBalancerDefault>

--- a/PsimagLite/src/Pthreads.h
+++ b/PsimagLite/src/Pthreads.h
@@ -86,8 +86,8 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #include <sched.h>
 #include <unistd.h>
 #ifdef _GNU_SOURCE
+#include <cstring>
 #include <errno.h>
-#include <string.h>
 #endif
 
 template <typename PthreadFunctionHolderType> struct PthreadFunctionStruct {

--- a/PsimagLite/src/PthreadsNg.h
+++ b/PsimagLite/src/PthreadsNg.h
@@ -98,8 +98,8 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #define _GNU_SOURCE
 #endif
 #ifdef _GNU_SOURCE
+#include <cstring>
 #include <errno.h>
-#include <string.h>
 #endif
 #ifndef PTHREAD_STACK_MIN
 #define PTHREAD_STACK_MIN 16384

--- a/src/GPUPlugin/analysis.h
+++ b/src/GPUPlugin/analysis.h
@@ -2,7 +2,7 @@
 #define ANALYSIS_H
 
 #include "Vector.h"
-#include <math.h>
+#include <cmath>
 
 typedef PsimagLite::Vector<SizeType>::Type VectorSizeType;
 

--- a/src/GPUPlugin/apply_Htarget_sparse_not_ready.cpp
+++ b/src/GPUPlugin/apply_Htarget_sparse_not_ready.cpp
@@ -1,6 +1,6 @@
 #include "dmrg_types.h"
 #include "dmrg_vbatch.h"
-#include <assert.h>
+#include <cassert>
 #ifdef _OPENMP
 #include <omp.h>
 #endif

--- a/src/GPUPlugin/dmrg_types.h
+++ b/src/GPUPlugin/dmrg_types.h
@@ -5,7 +5,7 @@ typedef int IntegerType;
 
 #if defined(USE_COMPLEX_Z)
 
-#include <complex.h>
+#include <complex>
 
 typedef std::complex<double> MYTYPE;
 

--- a/src/GPUPlugin/dmrg_vbatch.h
+++ b/src/GPUPlugin/dmrg_vbatch.h
@@ -3,7 +3,7 @@
 
 #include "Vector.h"
 #include "dmrg_types.h"
-#include <assert.h>
+#include <cassert>
 
 #ifdef USE_INTEL_MKL
 #include "dmrg_mkl.h"

--- a/src/GPUPlugin/gen_patches_comb.cpp
+++ b/src/GPUPlugin/gen_patches_comb.cpp
@@ -1,9 +1,9 @@
 #include "analysis.h"
 #include "dmrg_vbatch.h"
-#include <assert.h>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
 
 const SizeType idebug = 0;
 

--- a/src/GPUPlugin/setup_matrix.cpp
+++ b/src/GPUPlugin/setup_matrix.cpp
@@ -1,6 +1,6 @@
 #include "setup_matrix.h"
 #include "dmrg_types.h"
-#include <assert.h>
+#include <cassert>
 
 #if defined(USE_COMPLEX_Z)
 std::complex<double> makeFloat(double zr, double zi) { return std::complex<double>(zr, zi); }

--- a/src/GPUPlugin/setup_nC.cpp
+++ b/src/GPUPlugin/setup_nC.cpp
@@ -1,7 +1,7 @@
 #include "dmrg_types.h"
-#include <assert.h>
-#include <math.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
 
 #include "dmrg_vbatch.h"
 #include "setup_nC.h"

--- a/src/GPUPlugin/setup_vbatch.cpp
+++ b/src/GPUPlugin/setup_vbatch.cpp
@@ -2,10 +2,10 @@
 #include "dmrg_lapack.h"
 #include "dmrg_types.h"
 #include "dmrg_vbatch.h"
-#include <assert.h>
-#include <complex.h>
-#include <math.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cmath>
+#include <complex>
+#include <cstdlib>
 
 #if defined(USE_COMPLEX_Z)
 double ABS(std::complex<double> x) { return std::abs(x); }

--- a/src/GPUPlugin/test_gen_patches_comb.cpp
+++ b/src/GPUPlugin/test_gen_patches_comb.cpp
@@ -1,7 +1,7 @@
 #include "analysis.h"
 #include "dmrg_types.h"
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 /*
  ---------------------------------------

--- a/src/GPUPlugin/test_vbatch.cpp
+++ b/src/GPUPlugin/test_vbatch.cpp
@@ -6,14 +6,13 @@
 #include "setup_nC.h"
 #include "setup_sparse_batch.h"
 #include "setup_vbatch.h"
-#include <assert.h>
-#include <math.h>
 
-#include <assert.h>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <getopt.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/src/GPUPlugin/test_vbatch.h
+++ b/src/GPUPlugin/test_vbatch.h
@@ -9,7 +9,7 @@
 #include "setup_nC.h"
 #include "setup_sparse_batch.h"
 #include "setup_vbatch.h"
-#include <assert.h>
-#include <math.h>
+#include <cassert>
+#include <cmath>
 
 #endif

--- a/src/GPUPlugin/unsetup_sparse_batch.cpp
+++ b/src/GPUPlugin/unsetup_sparse_batch.cpp
@@ -1,7 +1,7 @@
 #include "dmrg_vbatch.h"
 #include "setup_sparse_batch.h"
-#include <assert.h>
-#include <complex.h>
+#include <cassert>
+#include <complex>
 
 template <typename T>
 void unsetup_sparse_batch(std::vector<T*>& gAbatch_, std::vector<T*>& gBbatch_)

--- a/src/GPUPlugin/unsetup_vbatch.cpp
+++ b/src/GPUPlugin/unsetup_vbatch.cpp
@@ -1,7 +1,7 @@
-#include <assert.h>
-#include <complex.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cassert>
+#include <complex>
+#include <cstdio>
+#include <cstdlib>
 
 #include "dmrg_vbatch.h"
 #include "setup_vbatch.h"

--- a/src/KronUtil/util.h
+++ b/src/KronUtil/util.h
@@ -5,9 +5,9 @@
 #include "GemmR.h"
 #include "KronUtil.h"
 #include "MatrixNonOwned.h"
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
 
 template <typename ComplexOrRealType>
 void estimate_kron_cost(const int          nrow_A,


### PR DESCRIPTION
In particular, fixing
```
/path/to/dmrgpp/src/GPUPlugin/unsetup_vbatch.cpp:2:10: warning: non-portable path to file '<Complex.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    2 | #include <complex.h>
      |          ^~~~~~~~~~~
      |          <Complex.h>
```