### PR TITLE
scaling gimp by 0.25

### DIFF
--- a/cincuenta/src/ImpuritySolverBase.h
+++ b/cincuenta/src/ImpuritySolverBase.h
@@ -64,6 +64,14 @@ public:
 
 		return sum;
 	}
+
+	static void scale(std::vector<ComplexOrRealType>& g)
+	{
+		const ComplexOrRealType factor = 0.25;
+		for (auto& val : g) {
+			val *= factor;
+		}
+	}
 	// public static END
 
 protected:

--- a/cincuenta/src/ImpuritySolverDmrg.h
+++ b/cincuenta/src/ImpuritySolverDmrg.h
@@ -81,7 +81,7 @@ public:
 
 		doType(DmrgType::TYPE_1, data3, impurity_site, freq_enum);
 
-		// scaleGimp();
+		BaseType::scale(gimp_);
 
 		freq_enum_ = freq_enum;
 
@@ -341,16 +341,6 @@ private:
 
 		if (ind < gimp_.size())
 			err("readGimp: Not all values computed\n");
-	}
-
-	void scaleGimp()
-	{
-		const SizeType n           = gimp_.size();
-		ComplexType    pre_density = BaseType::density(gimp_);
-		const RealType factor      = -M_PI / std::real(pre_density);
-		for (SizeType i = 0; i < n; ++i) {
-			gimp_[i] *= factor;
-		}
 	}
 
 	const ParamsDmftSolverType&     params_;

--- a/cincuenta/src/ImpuritySolverDmrg.h
+++ b/cincuenta/src/ImpuritySolverDmrg.h
@@ -81,8 +81,6 @@ public:
 
 		doType(DmrgType::TYPE_1, data3, impurity_site, freq_enum);
 
-		BaseType::scale(gimp_);
-
 		freq_enum_ = freq_enum;
 
 		PsimagLite::MPI::barrier(PsimagLite::MPI::COMM_WORLD);

--- a/cincuenta/src/ImpuritySolverExactDiag.h
+++ b/cincuenta/src/ImpuritySolverExactDiag.h
@@ -145,11 +145,7 @@ private:
 			sum += gimp_[i];
 		}
 
-		/*
-		RealType factor = -std::real(M_PI / sum);
-		for (SizeType i = 0; i < gimp_.size(); ++i)
-		        gimp_[i] *= factor;
-		*/
+		BaseType::scale(gimp_);
 	}
 
 	const ParamsDmftSolverType&     params_;


### PR DESCRIPTION
The Gimp scale of DMRG is correct and should not be scaled. The scale of EXACT is wrong and this PR fixes that temporarily. We'll need to fix properly later.