### PR TITLE
add <P.last|P> syntax for last Krylov slot overlap in TargetingExpression

### DIFF
--- a/PsimagLite/src/GetBraOrKet.h
+++ b/PsimagLite/src/GetBraOrKet.h
@@ -23,6 +23,7 @@ public:
 	    , braOrKet_(braOrKet)
 	    , kind_(Kind::E)
 	    , pair_(0, 0)
+	    , isLastKrylov_(false)
 	{
 		const SizeType l = braOrKet.length();
 		if (l < 2)
@@ -45,6 +46,8 @@ public:
 	bool isPvector() const { return (kind_ == Kind::P); }
 
 	bool isRvector() const { return (kind_ == Kind::R); }
+
+	bool isLastKrylov() const { return isLastKrylov_; }
 
 	SizeType levelIndex() const
 	{
@@ -100,6 +103,11 @@ private:
 		if (str.size() < 2)
 			return;
 
+		if (str == ".last") {
+			isLastKrylov_ = true;
+			return;
+		}
+
 		if (str[0] == 'X') {
 			pair_.second = getNumberFrom(str, 1); // modifies str
 		} else {
@@ -132,6 +140,7 @@ private:
 	String       braOrKet_;
 	Kind         kind_;
 	PairSizeType pair_;
+	bool         isLastKrylov_;
 };
 } // namespace PsimagLite
 #endif // GETBRAORKET_H

--- a/PsimagLite/src/GetBraOrKet.h
+++ b/PsimagLite/src/GetBraOrKet.h
@@ -1,7 +1,7 @@
 #ifndef GETBRAORKET_H
 #define GETBRAORKET_H
+#include "PsimagLite.h"
 #include "Vector.h"
-#include <cstdlib>
 
 namespace PsimagLite {
 

--- a/PsimagLite/src/tests/CMakeLists.txt
+++ b/PsimagLite/src/tests/CMakeLists.txt
@@ -14,3 +14,7 @@ catch_discover_tests(testArnoldiSaI)
 add_executable(test_InputPath test_InputPath.cpp)
 target_link_libraries(test_InputPath PRIVATE Catch2::Catch2WithMain psimaglite)
 catch_discover_tests(test_InputPath)
+
+add_executable(test_GetBraOrKet test_GetBraOrKet.cpp)
+target_link_libraries(test_GetBraOrKet PRIVATE Catch2::Catch2WithMain psimaglite)
+catch_discover_tests(test_GetBraOrKet)

--- a/PsimagLite/src/tests/test_GetBraOrKet.cpp
+++ b/PsimagLite/src/tests/test_GetBraOrKet.cpp
@@ -6,18 +6,18 @@ using G = PsimagLite::GetBraOrKet;
 
 TEST_CASE("GetBraOrKet ket vs bra detection", "[GetBraOrKet]")
 {
-	REQUIRE(G("|gs>").isKet() == true);
-	REQUIRE(G("<gs|").isKet() == false);
-	REQUIRE(G("|P3>").isKet() == true);
-	REQUIRE(G("<P3|").isKet() == false);
+	CHECK(G("|gs>").isKet() == true);
+	CHECK(G("<gs|").isKet() == false);
+	CHECK(G("|P3>").isKet() == true);
+	CHECK(G("<P3|").isKet() == false);
 }
 
 TEST_CASE("GetBraOrKet ground state", "[GetBraOrKet]")
 {
 	G gs("|gs>");
-	REQUIRE(gs.isPvector() == false);
-	REQUIRE(gs.isRvector() == false);
-	REQUIRE(gs.isLastKrylov() == false);
+	CHECK(gs.isPvector() == false);
+	CHECK(gs.isRvector() == false);
+	CHECK(gs.isLastKrylov() == false);
 }
 
 TEST_CASE("GetBraOrKet P-vector index parsing", "[GetBraOrKet]")
@@ -25,33 +25,33 @@ TEST_CASE("GetBraOrKet P-vector index parsing", "[GetBraOrKet]")
 	SECTION("P0")
 	{
 		G p0("|P0>");
-		REQUIRE(p0.isPvector() == true);
-		REQUIRE(p0.pIndex() == 0);
-		REQUIRE(p0.isLastKrylov() == false);
+		CHECK(p0.isPvector() == true);
+		CHECK(p0.pIndex() == 0);
+		CHECK(p0.isLastKrylov() == false);
 	}
 
 	SECTION("P2")
 	{
 		G p2("|P2>");
-		REQUIRE(p2.isPvector() == true);
-		REQUIRE(p2.pIndex() == 2);
-		REQUIRE(p2.isLastKrylov() == false);
+		CHECK(p2.isPvector() == true);
+		CHECK(p2.pIndex() == 2);
+		CHECK(p2.isLastKrylov() == false);
 	}
 
 	SECTION("P12 multi-digit")
 	{
 		G p12("|P12>");
-		REQUIRE(p12.isPvector() == true);
-		REQUIRE(p12.pIndex() == 12);
-		REQUIRE(p12.isLastKrylov() == false);
+		CHECK(p12.isPvector() == true);
+		CHECK(p12.pIndex() == 12);
+		CHECK(p12.isLastKrylov() == false);
 	}
 
 	SECTION("bra form <P2|")
 	{
 		G p2bra("<P2|");
-		REQUIRE(p2bra.isPvector() == true);
-		REQUIRE(p2bra.pIndex() == 2);
-		REQUIRE(p2bra.isKet() == false);
+		CHECK(p2bra.isPvector() == true);
+		CHECK(p2bra.pIndex() == 2);
+		CHECK(p2bra.isKet() == false);
 	}
 }
 
@@ -60,31 +60,31 @@ TEST_CASE("GetBraOrKet .last suffix", "[GetBraOrKet]")
 	SECTION("ket |P2.last>")
 	{
 		G p2last("|P2.last>");
-		REQUIRE(p2last.isPvector() == true);
-		REQUIRE(p2last.pIndex() == 2);
-		REQUIRE(p2last.isLastKrylov() == true);
-		REQUIRE(p2last.isKet() == true);
+		CHECK(p2last.isPvector() == true);
+		CHECK(p2last.pIndex() == 2);
+		CHECK(p2last.isLastKrylov() == true);
+		CHECK(p2last.isKet() == true);
 	}
 
 	SECTION("bra <P2.last|")
 	{
 		G p2lastBra("<P2.last|");
-		REQUIRE(p2lastBra.isPvector() == true);
-		REQUIRE(p2lastBra.pIndex() == 2);
-		REQUIRE(p2lastBra.isLastKrylov() == true);
-		REQUIRE(p2lastBra.isKet() == false);
+		CHECK(p2lastBra.isPvector() == true);
+		CHECK(p2lastBra.pIndex() == 2);
+		CHECK(p2lastBra.isLastKrylov() == true);
+		CHECK(p2lastBra.isKet() == false);
 	}
 
 	SECTION("P0.last")
 	{
 		G p0last("|P0.last>");
-		REQUIRE(p0last.pIndex() == 0);
-		REQUIRE(p0last.isLastKrylov() == true);
+		CHECK(p0last.pIndex() == 0);
+		CHECK(p0last.isLastKrylov() == true);
 	}
 
 	SECTION("regular P2 does not have .last set")
 	{
 		G p2("|P2>");
-		REQUIRE(p2.isLastKrylov() == false);
+		CHECK(p2.isLastKrylov() == false);
 	}
 }

--- a/PsimagLite/src/tests/test_GetBraOrKet.cpp
+++ b/PsimagLite/src/tests/test_GetBraOrKet.cpp
@@ -1,0 +1,90 @@
+#include "GetBraOrKet.h"
+#include "PsimagLite.h"
+#include <catch2/catch_test_macros.hpp>
+
+using G = PsimagLite::GetBraOrKet;
+
+TEST_CASE("GetBraOrKet ket vs bra detection", "[GetBraOrKet]")
+{
+	REQUIRE(G("|gs>").isKet() == true);
+	REQUIRE(G("<gs|").isKet() == false);
+	REQUIRE(G("|P3>").isKet() == true);
+	REQUIRE(G("<P3|").isKet() == false);
+}
+
+TEST_CASE("GetBraOrKet ground state", "[GetBraOrKet]")
+{
+	G gs("|gs>");
+	REQUIRE(gs.isPvector() == false);
+	REQUIRE(gs.isRvector() == false);
+	REQUIRE(gs.isLastKrylov() == false);
+}
+
+TEST_CASE("GetBraOrKet P-vector index parsing", "[GetBraOrKet]")
+{
+	SECTION("P0")
+	{
+		G p0("|P0>");
+		REQUIRE(p0.isPvector() == true);
+		REQUIRE(p0.pIndex() == 0);
+		REQUIRE(p0.isLastKrylov() == false);
+	}
+
+	SECTION("P2")
+	{
+		G p2("|P2>");
+		REQUIRE(p2.isPvector() == true);
+		REQUIRE(p2.pIndex() == 2);
+		REQUIRE(p2.isLastKrylov() == false);
+	}
+
+	SECTION("P12 multi-digit")
+	{
+		G p12("|P12>");
+		REQUIRE(p12.isPvector() == true);
+		REQUIRE(p12.pIndex() == 12);
+		REQUIRE(p12.isLastKrylov() == false);
+	}
+
+	SECTION("bra form <P2|")
+	{
+		G p2bra("<P2|");
+		REQUIRE(p2bra.isPvector() == true);
+		REQUIRE(p2bra.pIndex() == 2);
+		REQUIRE(p2bra.isKet() == false);
+	}
+}
+
+TEST_CASE("GetBraOrKet .last suffix", "[GetBraOrKet]")
+{
+	SECTION("ket |P2.last>")
+	{
+		G p2last("|P2.last>");
+		REQUIRE(p2last.isPvector() == true);
+		REQUIRE(p2last.pIndex() == 2);
+		REQUIRE(p2last.isLastKrylov() == true);
+		REQUIRE(p2last.isKet() == true);
+	}
+
+	SECTION("bra <P2.last|")
+	{
+		G p2lastBra("<P2.last|");
+		REQUIRE(p2lastBra.isPvector() == true);
+		REQUIRE(p2lastBra.pIndex() == 2);
+		REQUIRE(p2lastBra.isLastKrylov() == true);
+		REQUIRE(p2lastBra.isKet() == false);
+	}
+
+	SECTION("P0.last")
+	{
+		G p0last("|P0.last>");
+		REQUIRE(p0last.pIndex() == 0);
+		REQUIRE(p0last.isLastKrylov() == true);
+	}
+
+	SECTION("regular P2 does not have .last set")
+	{
+		G p2("|P2>");
+		REQUIRE(p2.isLastKrylov() == false);
+	}
+}

--- a/TestSuite/inputs/input9100.inp
+++ b/TestSuite/inputs/input9100.inp
@@ -1,0 +1,26 @@
+##Ainur1.0
+
+# Ground state of a 6-site Anderson impurity model (1 impurity + 5 bath)
+# with U=0 at all sites (non-interacting H_i).
+# Half-filling: 3 up + 3 down = 6 electrons on 6 sites.
+# Output checkpoint data9100 is loaded by input9102 as the pre-quench GS.
+
+TotalNumberOfSites=6;
+NumberOfTerms=1;
+DegreesOfFreedom=1;
+GeometryKind=star;
+GeometryOptions=none;
+hubbardU=[0, 0., 0., 0., 0., 0.];
+Model=HubbardOneBand;
+SolverOptions=twositedmrg,geometryallinsystem;
+Version=TSPEvolveGroundState-unit-test;
+OutputFile=data9100;
+InfiniteLoopKeptStates=50;
+FiniteLoops=[
+    [@auto, 50, 0], [@auto, 50, 0],
+    [@auto, 50, 0], [@auto, 50, 0]];
+TargetElectronsUp=3;
+TargetElectronsDown=3;
+dir0:Connectors=[0.5, 0.5, 0.5, 0.5, 0.5];
+potentialV=[0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0];

--- a/TestSuite/inputs/input9102.inp
+++ b/TestSuite/inputs/input9102.inp
@@ -1,0 +1,29 @@
+##Ainur1.0
+
+# U=0 -> U=2 interaction quench at the impurity (site 0), step 1 of 2.
+# Restarts from the U=0 ground state (data9100).  FiniteLoops with the "2"
+# (fast-WFT) flag prevents DMRG from re-optimising the ground state for U=2,
+# so |gs> remains |GS_i> (U=0) WFT-transformed to the current basis.
+# Computes P0 = c'[0]*|GS_i> for use as the initial hole state in step 2.
+
+TotalNumberOfSites=6;
+NumberOfTerms=1;
+DegreesOfFreedom=1;
+GeometryKind=star;
+GeometryOptions=none;
+hubbardU=[2, 0., 0., 0., 0., 0.];
+Model=HubbardOneBand;
+SolverOptions=twositedmrg,geometryallinsystem,TargetingExpression,restart;
+Version=GSquench-unit-test;
+OutputFile=data9102;
+InfiniteLoopKeptStates=50;
+FiniteLoops=[
+    [@auto, 50, 2], [@auto, 50, 2]];
+TargetElectronsUp=3;
+TargetElectronsDown=3;
+dir0:Connectors=[0.5, 0.5, 0.5, 0.5, 0.5];
+potentialV=[0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0];
+RestartFilename=data9100;
+string P0="c'[0]*|gs>";
+GsWeight=0.1;

--- a/TestSuite/inputs/input9103.inp
+++ b/TestSuite/inputs/input9103.inp
@@ -1,0 +1,40 @@
+##Ainur1.0
+
+# U=0 -> U=2 interaction quench at the impurity (site 0), step 2 of 2.
+# Restarts from data9102 (which holds P0 = c'[0]*|GS_i> with |GS_i> = U=0 GS).
+# The "2" FiniteLoops flag keeps |gs> as the WFT-transformed |GS_i> throughout.
+#
+# P1 = e^{-iH_f t} c'|GS_i>   (particle target, N+1 sector)
+# P2 = e^{-iH_f t} |GS_i>     (evolved bra, N sector)
+#
+# In-situ measurement <P2|c|P1> = <GS_i|e^{iH_f t} c e^{-iH_f t} c'|GS_i> = G^>(t,0)
+# <P2.last|P2> gives the consecutive N-sector overlap for gauge-phase correction.
+
+TotalNumberOfSites=6;
+NumberOfTerms=1;
+DegreesOfFreedom=1;
+GeometryKind=star;
+GeometryOptions=none;
+hubbardU=[2, 0., 0., 0., 0., 0.];
+Model=HubbardOneBand;
+SolverOptions=twositedmrg,geometryallinsystem,TargetingExpression,restart,usecomplex;
+Version=GSquench-unit-test;
+OutputFile=data9103;
+InfiniteLoopKeptStates=50;
+FiniteLoops=[
+    [@auto, 50, 2], [@auto, 50, 2],
+    [@auto, 50, 2], [@auto, 50, 2],
+    [@auto, 50, 2], [@auto, 50, 2]];
+TargetElectronsUp=3;
+TargetElectronsDown=3;
+dir0:Connectors=[0.5, 0.5, 0.5, 0.5, 0.5];
+potentialV=[0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0];
+RestartFilename=data9102;
+RestartMappingTvs=[0, -1, -1];
+string P0=|P0>;
+string P1="TimeEvolve{tau=0.1,steps=5,advanceEach=4}*|P0>";
+string P2="TimeEvolve{tau=0.1,steps=5,advanceEach=4}*|gs>";
+GsWeight=0.1;
+
+#ci dmrg arguments="<P2|c|P1>,<P2.last|P2>"

--- a/dmrg/CMakeLists.txt
+++ b/dmrg/CMakeLists.txt
@@ -40,6 +40,10 @@ target_link_libraries(introspect dmrgpp_utils dmrg_runner)
 
 add_subdirectory(GPUPlugin)
 
+if(BUILD_TESTING)
+  add_subdirectory(Engine/tests)
+endif()
+
 if(BUILD_SHARED_LIBS)
   install(TARGETS dmrg_runner dmrgpp_utils LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()

--- a/dmrg/CMakeLists.txt
+++ b/dmrg/CMakeLists.txt
@@ -185,6 +185,22 @@ add_test(NAME input9000 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input9000.ain) # ene
 add_test(NAME input9001 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input9001.ain "<P0|n|P0>"
 )# in-situ 1 (1.010966,0.000000) 0.500000 <P0|n|P0> (1.000000,0.000000)
 
+# U=0->U=2 quench unit tests using TargetingExpression + TimeEvolve P.last syntax
+# input9100: GS of H_i (U=0); energy = -sqrt(5) for uniform hopping 0.5
+add_test(NAME input9100 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input9100.inp) # energy -2.23607
+add_lowest_eigenvalue_check_test(output9100 -2.23607 runForinput9100.cout)
+# input9102: TargetingExpression restart from 9100, computes P0 = c'[0]*|GS_i>
+add_test(NAME input9102 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input9102.inp)
+set_tests_properties(input9102 PROPERTIES DEPENDS input9100)
+# input9103: tDMRG under H_f, measures <P2|c|P1> and consecutive overlap <P2.last|P2>
+add_test(NAME input9103 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input9103.inp "<P2|c|P1>,<P2.last|P2>")
+set_tests_properties(input9103 PROPERTIES DEPENDS input9102)
+add_test(NAME output9103_P2cP1 COMMAND sh -c "grep -q '<P2|c|P1>' ${CMAKE_CURRENT_BINARY_DIR}/runForinput9103.cout")
+set_tests_properties(output9103_P2cP1 PROPERTIES DEPENDS input9103)
+add_test(NAME output9103_P2lastP2 COMMAND sh -c
+                                          "grep -q '<P2.last|P2>' ${CMAKE_CURRENT_BINARY_DIR}/runForinput9103.cout")
+set_tests_properties(output9103_P2lastP2 PROPERTIES DEPENDS input9103)
+
 # Tests for the observe executable
 add_test(NAME observe0002 COMMAND ./observe -l "+r" -f ${PATH_TO_INPUTS}/input2.ain
                                   "<gs|c';c|gs>,<gs|2.0*sz;2.0*sz|gs>,<gs|n;n|gs>")

--- a/dmrg/Engine/ApplyOperatorExpression.h
+++ b/dmrg/Engine/ApplyOperatorExpression.h
@@ -74,6 +74,7 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #include "ApplyOperatorLocal.h"
 #include "CorrelationsSkeleton.h"
 #include "Io/IoSelector.h"
+#include "LastKrylovSlots.h"
 #include "MultiSiteExpressionHelper.h"
 #include "ProgressIndicator.h"
 #include "StageEnum.h"
@@ -82,7 +83,6 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #include "TimeVectorsKrylov.h"
 #include "TimeVectorsRungeKutta.h"
 #include "TimeVectorsSuzukiTrotter.h"
-#include <map>
 
 namespace Dmrg {
 
@@ -456,14 +456,10 @@ public:
 
 	void registerLastKrylovSlot(SizeType pIndex, SizeType slotIndex)
 	{
-		pIndexToLastKrylovSlot_[pIndex] = slotIndex;
+		lastKrylovSlots_.registerSlot(pIndex, slotIndex);
 	}
 
-	int getLastKrylovSlot(SizeType pIndex) const
-	{
-		auto it = pIndexToLastKrylovSlot_.find(pIndex);
-		return (it == pIndexToLastKrylovSlot_.end()) ? -1 : static_cast<int>(it->second);
-	}
+	int getLastKrylovSlot(SizeType pIndex) const { return lastKrylovSlots_.getSlot(pIndex); }
 
 	void destroyPvector(SizeType ind)
 	{
@@ -916,7 +912,7 @@ private:
 	ApplyOperatorType                     applyOpLocal_;
 	VectorVectorVectorWithOffsetType      psi_;
 	VectorVectorWithOffsetType            targetVectors_;
-	std::map<SizeType, SizeType>          pIndexToLastKrylovSlot_;
+	LastKrylovSlots                       lastKrylovSlots_;
 	TimeVectorsBaseType*                  timeVectorsBase_;
 	WftHelperType                         wftHelper_;
 	mutable MultiSiteExpressionHelperType multiSiteExprHelper_;

--- a/dmrg/Engine/ApplyOperatorExpression.h
+++ b/dmrg/Engine/ApplyOperatorExpression.h
@@ -82,6 +82,7 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 #include "TimeVectorsKrylov.h"
 #include "TimeVectorsRungeKutta.h"
 #include "TimeVectorsSuzukiTrotter.h"
+#include <map>
 
 namespace Dmrg {
 
@@ -451,6 +452,17 @@ public:
 		targetVectors_.push_back(v);
 		*targetVectors_[n] = vv;
 		return n;
+	}
+
+	void registerLastKrylovSlot(SizeType pIndex, SizeType slotIndex)
+	{
+		pIndexToLastKrylovSlot_[pIndex] = slotIndex;
+	}
+
+	int getLastKrylovSlot(SizeType pIndex) const
+	{
+		auto it = pIndexToLastKrylovSlot_.find(pIndex);
+		return (it == pIndexToLastKrylovSlot_.end()) ? -1 : static_cast<int>(it->second);
 	}
 
 	void destroyPvector(SizeType ind)
@@ -904,6 +916,7 @@ private:
 	ApplyOperatorType                     applyOpLocal_;
 	VectorVectorVectorWithOffsetType      psi_;
 	VectorVectorWithOffsetType            targetVectors_;
+	std::map<SizeType, SizeType>          pIndexToLastKrylovSlot_;
 	TimeVectorsBaseType*                  timeVectorsBase_;
 	WftHelperType                         wftHelper_;
 	mutable MultiSiteExpressionHelperType multiSiteExprHelper_;

--- a/dmrg/Engine/AuxForTargetingExpression.h
+++ b/dmrg/Engine/AuxForTargetingExpression.h
@@ -72,6 +72,19 @@ public:
 		    "getCurrentVectorNonConst: psi or tvs cannot be modified\n");
 	}
 
+	const VectorWithOffsetType& getCurrentVectorConst(PsimagLite::String braOrKet) const
+	{
+		PsimagLite::GetBraOrKet getBraOrKet(braOrKet);
+		if (getBraOrKet.isPvector() && getBraOrKet.isLastKrylov()) {
+			const int lastSlot = timeEvolve_.getLastIndex(getBraOrKet.pIndex());
+			if (lastSlot < 0)
+				err("getCurrentVectorConst: no time evolution found for " + braOrKet
+				    + "\n");
+			return pVectors_.aoe().targetVectors(static_cast<SizeType>(lastSlot));
+		}
+		return pVectors_.getCurrentVectorConst(braOrKet);
+	}
+
 	PsimagLite::String createTemporaryVector(PsimagLite::String str) const
 	{
 		const SizeType n = tempVectors_.size();

--- a/dmrg/Engine/GroupOfOneTimeEvolutions.h
+++ b/dmrg/Engine/GroupOfOneTimeEvolutions.h
@@ -37,6 +37,8 @@ template <typename PvectorsType> class GroupOfOneTimeEvolutions {
 				};
 
 				pVectors.createNew(src, lambda);
+				if (i == timeSteps - 1)
+					pVectors.registerLastKrylovSlot(firstIndex, indices_[i]);
 			}
 		}
 
@@ -114,6 +116,17 @@ public:
 	}
 
 	void pushBack(OneTimeEvolution* ptr) { vEvolutions_.push_back(ptr); }
+
+	int getLastIndex(SizeType firstIndex) const
+	{
+		const SizeType n = vEvolutions_.size();
+		for (SizeType i = 0; i < n; ++i) {
+			const auto& idx = vEvolutions_[i]->indices();
+			if (idx[0] == firstIndex)
+				return idx[idx.size() - 1];
+		}
+		return -1;
+	}
 
 	SizeType size() const { return vEvolutions_.size(); }
 

--- a/dmrg/Engine/LastKrylovSlots.h
+++ b/dmrg/Engine/LastKrylovSlots.h
@@ -1,0 +1,30 @@
+#ifndef LASTKRYLOVSLOTS_H
+#define LASTKRYLOVSLOTS_H
+#include "Vector.h"
+#include <map>
+
+namespace Dmrg {
+
+// Maps a P-vector's primary targetVectors_ slot index to the last Krylov slot
+// allocated for its time evolution.  Stored here so both Pvectors (which registers
+// the slot) and TargetingCommon (which resolves |P.last> labels) can reach it
+// through their shared ApplyOperatorExpression.
+class LastKrylovSlots {
+
+public:
+
+	void registerSlot(SizeType pIndex, SizeType slotIndex) { map_[pIndex] = slotIndex; }
+
+	int getSlot(SizeType pIndex) const
+	{
+		const auto it = map_.find(pIndex);
+		return (it == map_.end()) ? -1 : static_cast<int>(it->second);
+	}
+
+private:
+
+	std::map<SizeType, SizeType> map_;
+};
+
+} // namespace Dmrg
+#endif // LASTKRYLOVSLOTS_H

--- a/dmrg/Engine/NonLocalForTargetingExpression.h
+++ b/dmrg/Engine/NonLocalForTargetingExpression.h
@@ -72,7 +72,7 @@ public:
 		OneTimeEvolutionType* oneTimeEvolution
 		    = aux_.timeEvolve().findThisEvolution(firstIndex);
 
-		const VectorWithOffsetType* srcVwo = &aux_.pVectors().getCurrentVectorConst(srcKet);
+		const VectorWithOffsetType* srcVwo = &aux_.getCurrentVectorConst(srcKet);
 		if (srcVwo->size() == 0 && !oneTimeEvolution)
 			return false;
 

--- a/dmrg/Engine/Pvectors.h
+++ b/dmrg/Engine/Pvectors.h
@@ -101,6 +101,11 @@ public:
 		progress_.printline(msgg, std::cout);
 	}
 
+	void registerLastKrylovSlot(SizeType pIndex, SizeType slotIndex)
+	{
+		aoeNonConst().registerLastKrylovSlot(pIndex, slotIndex);
+	}
+
 	SizeType targets() const { return pVectors_.size(); }
 
 	SizeType origPvectors() const { return origPvectors_; }

--- a/dmrg/Engine/TargetingCommon.h
+++ b/dmrg/Engine/TargetingCommon.h
@@ -825,6 +825,13 @@ private:
 	const VectorWithOffsetType* getVector(const PsimagLite::GetBraOrKet& getBraOrKet) const
 	{
 		if (getBraOrKet.isPvector()) {
+			if (getBraOrKet.isLastKrylov()) {
+				const int lastSlot = aoe_.getLastKrylovSlot(getBraOrKet.pIndex());
+				if (lastSlot < 0)
+					return nullptr;
+				const SizeType slot = static_cast<SizeType>(lastSlot);
+				return (slot >= aoe_.tvs()) ? nullptr : &(aoe_.targetVectors(slot));
+			}
 			const SizeType pIndex = getBraOrKet.pIndex();
 			return (pIndex >= aoe_.tvs()) ? nullptr : &(aoe_.targetVectors(pIndex));
 		}

--- a/dmrg/Engine/TermForTargetingExpression.h
+++ b/dmrg/Engine/TermForTargetingExpression.h
@@ -224,7 +224,7 @@ private:
 	                 SizeType            site)
 	{
 		assert(siteCanBeApplied(site));
-		const VectorWithOffsetType& srcVwo = aux_.pVectors().getCurrentVectorConst(srcKet);
+		const VectorWithOffsetType& srcVwo       = aux_.getCurrentVectorConst(srcKet);
 		PsimagLite::String          internalName = aux_.createTemporaryVector(destKet);
 		VectorWithOffsetType&       destVwo = aux_.getCurrentVectorNonConst(internalName);
 		applyInSitu(destVwo, srcVwo, site, op);

--- a/dmrg/Engine/tests/CMakeLists.txt
+++ b/dmrg/Engine/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(test_ApplyOperatorExpression test_ApplyOperatorExpression.cpp)
+target_link_libraries(test_ApplyOperatorExpression PRIVATE Catch2::Catch2WithMain psimaglite)
+target_include_directories(test_ApplyOperatorExpression PRIVATE ${CMAKE_SOURCE_DIR}/dmrg/Engine)
+catch_discover_tests(test_ApplyOperatorExpression)

--- a/dmrg/Engine/tests/CMakeLists.txt
+++ b/dmrg/Engine/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_ApplyOperatorExpression test_ApplyOperatorExpression.cpp)
-target_link_libraries(test_ApplyOperatorExpression PRIVATE Catch2::Catch2WithMain psimaglite)
-target_include_directories(test_ApplyOperatorExpression PRIVATE ${CMAKE_SOURCE_DIR}/dmrg/Engine)
-catch_discover_tests(test_ApplyOperatorExpression)
+add_executable(test_LastKrylovSlots test_LastKrylovSlots.cpp)
+target_link_libraries(test_LastKrylovSlots PRIVATE Catch2::Catch2WithMain psimaglite)
+target_include_directories(test_LastKrylovSlots PRIVATE ${CMAKE_SOURCE_DIR}/dmrg/Engine)
+catch_discover_tests(test_LastKrylovSlots)

--- a/dmrg/Engine/tests/test_ApplyOperatorExpression.cpp
+++ b/dmrg/Engine/tests/test_ApplyOperatorExpression.cpp
@@ -1,0 +1,45 @@
+#include "LastKrylovSlots.h"
+#include "PsimagLite.h"
+#include <catch2/catch_test_macros.hpp>
+
+// LastKrylovSlots is the registry extracted from ApplyOperatorExpression that
+// maps a P-vector's primary slot index to the last Krylov slot allocated for
+// its time evolution.  ApplyOperatorExpression delegates its
+// registerLastKrylovSlot / getLastKrylovSlot methods to this class.
+
+using Dmrg::LastKrylovSlots;
+
+TEST_CASE("LastKrylovSlots returns -1 for unregistered index", "[LastKrylovSlots]")
+{
+	LastKrylovSlots reg;
+	REQUIRE(reg.getSlot(0) == -1);
+	REQUIRE(reg.getSlot(5) == -1);
+}
+
+TEST_CASE("LastKrylovSlots registers and retrieves a single slot", "[LastKrylovSlots]")
+{
+	LastKrylovSlots reg;
+	reg.registerSlot(2, 7);
+	REQUIRE(reg.getSlot(2) == 7);
+}
+
+TEST_CASE("LastKrylovSlots handles multiple P-vectors independently", "[LastKrylovSlots]")
+{
+	LastKrylovSlots reg;
+	reg.registerSlot(0, 4);
+	reg.registerSlot(1, 8);
+	reg.registerSlot(3, 12);
+
+	REQUIRE(reg.getSlot(0) == 4);
+	REQUIRE(reg.getSlot(1) == 8);
+	REQUIRE(reg.getSlot(2) == -1); // never registered
+	REQUIRE(reg.getSlot(3) == 12);
+}
+
+TEST_CASE("LastKrylovSlots overwrites on re-registration", "[LastKrylovSlots]")
+{
+	LastKrylovSlots reg;
+	reg.registerSlot(0, 4);
+	reg.registerSlot(0, 9);
+	REQUIRE(reg.getSlot(0) == 9);
+}

--- a/dmrg/Engine/tests/test_LastKrylovSlots.cpp
+++ b/dmrg/Engine/tests/test_LastKrylovSlots.cpp
@@ -2,11 +2,6 @@
 #include "PsimagLite.h"
 #include <catch2/catch_test_macros.hpp>
 
-// LastKrylovSlots is the registry extracted from ApplyOperatorExpression that
-// maps a P-vector's primary slot index to the last Krylov slot allocated for
-// its time evolution.  ApplyOperatorExpression delegates its
-// registerLastKrylovSlot / getLastKrylovSlot methods to this class.
-
 using Dmrg::LastKrylovSlots;
 
 TEST_CASE("LastKrylovSlots returns -1 for unregistered index", "[LastKrylovSlots]")

--- a/dmrg/Engine/tests/test_LastKrylovSlots.cpp
+++ b/dmrg/Engine/tests/test_LastKrylovSlots.cpp
@@ -7,15 +7,15 @@ using Dmrg::LastKrylovSlots;
 TEST_CASE("LastKrylovSlots returns -1 for unregistered index", "[LastKrylovSlots]")
 {
 	LastKrylovSlots reg;
-	REQUIRE(reg.getSlot(0) == -1);
-	REQUIRE(reg.getSlot(5) == -1);
+	CHECK(reg.getSlot(0) == -1);
+	CHECK(reg.getSlot(5) == -1);
 }
 
 TEST_CASE("LastKrylovSlots registers and retrieves a single slot", "[LastKrylovSlots]")
 {
 	LastKrylovSlots reg;
 	reg.registerSlot(2, 7);
-	REQUIRE(reg.getSlot(2) == 7);
+	CHECK(reg.getSlot(2) == 7);
 }
 
 TEST_CASE("LastKrylovSlots handles multiple P-vectors independently", "[LastKrylovSlots]")
@@ -25,10 +25,10 @@ TEST_CASE("LastKrylovSlots handles multiple P-vectors independently", "[LastKryl
 	reg.registerSlot(1, 8);
 	reg.registerSlot(3, 12);
 
-	REQUIRE(reg.getSlot(0) == 4);
-	REQUIRE(reg.getSlot(1) == 8);
-	REQUIRE(reg.getSlot(2) == -1); // never registered
-	REQUIRE(reg.getSlot(3) == 12);
+	CHECK(reg.getSlot(0) == 4);
+	CHECK(reg.getSlot(1) == 8);
+	CHECK(reg.getSlot(2) == -1); // never registered
+	CHECK(reg.getSlot(3) == 12);
 }
 
 TEST_CASE("LastKrylovSlots overwrites on re-registration", "[LastKrylovSlots]")
@@ -36,5 +36,5 @@ TEST_CASE("LastKrylovSlots overwrites on re-registration", "[LastKrylovSlots]")
 	LastKrylovSlots reg;
 	reg.registerSlot(0, 4);
 	reg.registerSlot(0, 9);
-	REQUIRE(reg.getSlot(0) == 9);
+	CHECK(reg.getSlot(0) == 9);
 }


### PR DESCRIPTION
## Summary

This implements the `<P2.last|P2>` syntax proposed by Gonzalo as a cleaner
alternative to the `overlap=1` feature on `pr/dmrgpp-tsp-evolve-gs`. It allows
consecutive self-overlap of a time-evolved P-vector to be computed as a standard
in-situ TargetingExpression measurement, without any special-casing in
`TargetingTimeStep`.

**Motivation:** the neq-DMFT driver needs a gauge-correction phase at each time
step, obtained from ⟨ψ(t)|ψ(t+τ)⟩. With `TimeEvolve{...}*|gs>` defining P2,
writing `<P2.last|P2>` in the `ci dmrg arguments` string produces that overlap
at every site/sweep without extending `targetVectors_` semantics.

## Changes

**PsimagLite**
- `GetBraOrKet.h`: parse `.last` suffix on P-vector labels; sets `isLastKrylov_`

**DMRG++ engine**
- `LastKrylovSlots.h` (new): tiny registry mapping `pIndex → lastKrylovSlot`
- `ApplyOperatorExpression.h`: delegates `registerLastKrylovSlot` / `getLastKrylovSlot` to `LastKrylovSlots`
- `GroupOfOneTimeEvolutions.h`: calls `registerLastKrylovSlot` when the last auxiliary Krylov slot is created; adds `getLastIndex()` query
- `Pvectors.h`: delegates `registerLastKrylovSlot` to `aoeNonConst()`
- `AuxForTargetingExpression.h`: `getCurrentVectorConst()` routes `.last` labels through `timeEvolve_.getLastIndex()`
- `TargetingCommon.h`: `getVector()` routes `.last` labels through `aoe_.getLastKrylovSlot()`
- `NonLocalForTargetingExpression.h`, `TermForTargetingExpression.h`: vector lookup routed through `aux_.getCurrentVectorConst()`

**Tests**
- `TestSuite/inputs/input9100.inp`, `input9102.inp`, `input9103.inp`: three-run chain (GS → operator application → time evolution) with `<P2.last|P2>` in input9103
- `dmrg/CMakeLists.txt`: registers the three integration tests
- `PsimagLite/src/tests/test_GetBraOrKet.cpp`: 30 Catch2 assertions covering ket/bra detection, P-index parsing, and the new `.last` suffix
- `dmrg/Engine/tests/test_LastKrylovSlots.cpp`: 8 Catch2 assertions covering the slot registry (unregistered lookup, single registration, multiple independent P-vectors, overwrite)

## Test plan

- [x] All three integration tests pass (`input9100`, `input9102`, `input9103`)
- [x] `<P2.last|P2>` output verified in `runForinput9103.cout`
- [x] `test_GetBraOrKet` — 30 assertions, all pass
- [x] `test_LastKrylovSlots` — 8 assertions, all pass
- [x] `dmrg` executable builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)