### PR TITLE
fix header guard collision

### DIFF
--- a/LanczosPlusPlus/src/Engine/InputCheck.h
+++ b/LanczosPlusPlus/src/Engine/InputCheck.h
@@ -76,8 +76,8 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
  *
  *  InputChecking functions
  */
-#ifndef INPUT_CHECK_H
-#define INPUT_CHECK_H
+#ifndef LPP_INPUT_CHECK_H
+#define LPP_INPUT_CHECK_H
 #include "Geometry/Geometry.h"
 #include "Options.h"
 #include <stdexcept>

--- a/dmrg/Engine/InputCheck.h
+++ b/dmrg/Engine/InputCheck.h
@@ -75,8 +75,8 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
  *
  *  InputChecking functions
  */
-#ifndef INPUT_CHECK_H
-#define INPUT_CHECK_H
+#ifndef DMRG_INPUT_CHECK_H
+#define DMRG_INPUT_CHECK_H
 #include "../../PsimagLite/src/Options.h"
 #include "Geometry/Geometry.h"
 #include "MatrixVectorKron/BatchedGemmInclude.hh"


### PR DESCRIPTION
I needed to do this to facilitate some integration testing in PR #199

We had a header guard collision between two previous separate modules, fixed.