### PR TITLE
Fix typo in dmrg/Engine/HamiltonianConnection.h

### DIFF
--- a/dmrg/Engine/HamiltonianConnection.h
+++ b/dmrg/Engine/HamiltonianConnection.h
@@ -314,7 +314,7 @@ private:
 				// Factor added in the input file for this geometry term
 				const std::string& geometry_factor = hamAbstract_.superGeometry()
 				                                         .geometry()
-				                                         .term(termIndex)
+				                                         .term(termIndexForGeom)
 				                                         .factor();
 
 				// default_value = 1.0, that is, if factor is not present


### PR DESCRIPTION
Running `TestSuite/inputs/input6024.inp` without this fix runs into an out-of-bounds error.