### PR TITLE
Remove unused CHECK_VALUE_TARGET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ else()
 endif()
 
 add_subdirectory(util)
-set(CHECK_VALUE_TARGET util::check_values)
 
 add_subdirectory(PsimagLite)
 add_subdirectory(dmrg)


### PR DESCRIPTION
Follow-up to https://github.com/dmrgpp-project/dmrgpp/pull/176. `util::check_values` never existed (but `util::check_value` does). Therefore, `CHECK_VALUE_TARGET` could never have been used.