### PR TITLE
Fix treatment of build type in CI

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -25,14 +25,19 @@ jobs:
 
     - name: Configure
       run: |
-        cmake -S ${{github.workspace}}/source -B ${{github.workspace}}/build -GNinja -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wno-unused-parameter" -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+        cmake -S ${{github.workspace}}/source \
+              -B ${{github.workspace}}/build \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+              -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wno-unused-parameter" \
+              -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build
 
     - name: Test
-      run: ctest --test-dir ${{github.workspace}}/build -C ${{env.BUILD_TYPE}} -E ^output3$ -LE Nightly --output-on-failure
+      run: ctest --test-dir ${{github.workspace}}/build -E ^output3$ -LE Nightly --output-on-failure
 
     - name: Install
-      run: cmake --install ${{github.workspace}}/build --prefix ${{github.workspace}}/install --config ${{env.BUILD_TYPE}}
+      run: cmake --install ${{github.workspace}}/build --prefix ${{github.workspace}}/install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,16 @@ jobs:
         cmake -S ${{github.workspace}}/source \
               -B ${{github.workspace}}/build \
               -GNinja \
-              -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+              -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
               -DCMAKE_CXX_FLAGS="-Wall -Wextra -Wno-unused-parameter" \
               -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
               -DPSIMAGLITE_USE_KOKKOS=ON
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
+      run: cmake --build ${{github.workspace}}/build
 
     - name: Test
-      run: ctest --test-dir ${{github.workspace}}/build -C ${{matrix.build_type}} -LE Nightly --output-on-failure
+      run: ctest --test-dir ${{github.workspace}}/build -LE Nightly --output-on-failure
 
     - name: Install
-      run: cmake --install ${{github.workspace}}/build --prefix ${{github.workspace}}/install --config ${{matrix.build_type}}
+      run: cmake --install ${{github.workspace}}/build --prefix ${{github.workspace}}/install


### PR DESCRIPTION
The build type wasn't used when configuring with `CMake` in the CI since `build_type` doesn't exist as environment variable but only as part of the matrix. The typo was introduced in https://github.com/dmrgpp-project/dmrgpp/commit/5c7644b20e7cf7cf4cd306e384d9a8d1245975f7.
Also, `--config` is redundant if we specify a build type (and with a single configuration build generator).