### PR TITLE
Port csr_kron_mult::imethod3

### DIFF
--- a/dmrg/KronUtil/csr_kron_mult.cpp
+++ b/dmrg/KronUtil/csr_kron_mult.cpp
@@ -1,4 +1,7 @@
 #include "util.h"
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Profiling_ScopedRegion.hpp>
+#include <PsimagLite/KokkosType.h>
 
 #include <Kokkos_Profiling_ScopedRegion.hpp>
 
@@ -279,43 +282,118 @@ void csr_kron_mult_method(const int  imethod,
 		 * ---------------------------------------------
 		 */
 
-		int ia = 0;
-		int ka = 0;
-		int ib = 0;
-		int kb = 0;
-		for (ia = 0; ia < nrow_A; ia++) {
-			int istarta = a.getRowPtr(ia);
-			int ienda   = a.getRowPtr(ia + 1);
-			for (ka = istarta; ka < ienda; ka++) {
-				int               ja  = a.getCol(ka);
-				ComplexOrRealType aij = a.getValue(ka);
-				if (is_complex && isConjTransA) {
-					aij = PsimagLite::conj(aij);
-				};
+		// Build flat lists of nonzeros for A and B on the host, then copy to device
+		using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+		using MemorySpace    = ExecutionSpace::memory_space;
+		using KokkosScalar   = typename PsimagLite::KokkosType<ComplexOrRealType>::type;
 
-				for (ib = 0; ib < nrow_B; ib++) {
-					int istartb = b.getRowPtr(ib);
-					int iendb   = b.getRowPtr(ib + 1);
+		int nnzA = a.nonZeros();
+		int nnzB = b.nonZeros();
 
-					for (kb = istartb; kb < iendb; kb++) {
-						int               jb  = b.getCol(kb);
-						ComplexOrRealType bij = b.getValue(kb);
-						if (is_complex && isConjTransB) {
-							bij = PsimagLite::conj(bij);
-						};
+		// create device views
+		Kokkos::View<int*, Kokkos::HostSpace> A_row_h(
+		    Kokkos::view_alloc(Kokkos::WithoutInitializing, "A_row_h"), nnzA);
+		Kokkos::View<const int*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged> A_col_h(
+		    &a.getCol(0), nnzA);
+		Kokkos::View<const KokkosScalar*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
+		    A_val_h(reinterpret_cast<const KokkosScalar*>(&a.getValue(0)), nnzA);
+		Kokkos::View<int*, Kokkos::HostSpace> B_row_h(
+		    Kokkos::view_alloc(Kokkos::WithoutInitializing, "B_row_h"), nnzB);
+		Kokkos::View<const int*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged> B_col_h(
+		    &b.getCol(0), nnzB);
+		Kokkos::View<const KokkosScalar*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
+		    B_val_h(reinterpret_cast<const KokkosScalar*>(&b.getValue(0)), nnzB);
 
-						ComplexOrRealType cij = aij * bij;
+		{
+			Kokkos::Profiling::ScopedRegion region(
+			    "PsimgLite::csr_kron_mult_method::imethod3::fill_AB");
 
-						int ix = (isTransB || isConjTransB) ? jb : ib;
-						int jx = (isTransA || isConjTransA) ? ja : ia;
-						int iy = (isTransB || isConjTransB) ? ib : jb;
-						int jy = (isTransA || isConjTransA) ? ia : ja;
+			// host-side temporary arrays
+			int idx = 0;
+			for (int ia = 0; ia < nrow_A; ++ia) {
+				int istart = a.getRowPtr(ia);
+				int iend   = a.getRowPtr(ia + 1);
+				for (int ka = istart; ka < iend; ++ka) {
+					A_row_h[idx] = ia;
+					++idx;
+				}
+			}
 
-						xout(ix, jx) += cij * yin(iy, jy);
-					};
-				};
-			};
-		};
+			idx = 0;
+			for (int ib = 0; ib < nrow_B; ++ib) {
+				int istart = b.getRowPtr(ib);
+				int iend   = b.getRowPtr(ib + 1);
+				for (int kb = istart; kb < iend; ++kb) {
+					B_row_h[idx] = ib;
+					++idx;
+				}
+			}
+		}
+
+		auto A_row_dev = Kokkos::create_mirror_view_and_copy(
+		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), A_row_h);
+		auto A_col_dev = Kokkos::create_mirror_view_and_copy(
+		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), A_col_h);
+		auto A_val_dev = Kokkos::create_mirror_view_and_copy(
+		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), A_val_h);
+		auto B_row_dev = Kokkos::create_mirror_view_and_copy(
+		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), B_row_h);
+		auto B_col_dev = Kokkos::create_mirror_view_and_copy(
+		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), B_col_h);
+		auto B_val_dev = Kokkos::create_mirror_view_and_copy(
+		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), B_val_h);
+		// device yin and xout
+
+		auto yin_host = Kokkos::View<const KokkosScalar**,
+		                             Kokkos::LayoutLeft,
+		                             Kokkos::HostSpace,
+		                             Kokkos::MemoryUnmanaged>(
+		    reinterpret_cast<const KokkosScalar*>(&yin(0, 0)), nrow_Y, ncol_Y);
+
+		auto y_dev = Kokkos::create_mirror_view_and_copy(
+		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), yin_host);
+
+		auto x_dev = Kokkos::View<KokkosScalar**>("x_dev", nrow_X, ncol_X);
+
+		const size_t totalPairs = static_cast<size_t>(nnzA) * static_cast<size_t>(nnzB);
+
+		Kokkos::parallel_for(
+		    "csr_kron_mult::imethod3_pairs",
+		    Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2>>({ 0, 0 },
+		                                                           { nnzB, nnzA }),
+		    KOKKOS_LAMBDA(const size_t ib_idx, const size_t ia_idx) {
+			    int          ia  = A_row_dev(ia_idx);
+			    int          ja  = A_col_dev(ia_idx);
+			    KokkosScalar aij = A_val_dev(ia_idx);
+			    if constexpr (is_complex)
+				    if (isConjTransA)
+					    aij = Kokkos::conj(aij);
+
+			    int          ib  = B_row_dev(ib_idx);
+			    int          jb  = B_col_dev(ib_idx);
+			    KokkosScalar bij = B_val_dev(ib_idx);
+			    if constexpr (is_complex)
+				    if (isConjTransB)
+					    bij = Kokkos::conj(bij);
+
+			    KokkosScalar cij = aij * bij;
+
+			    int ix = (isTransB || isConjTransB) ? jb : ib;
+			    int jx = (isTransA || isConjTransA) ? ja : ia;
+			    int iy = (isTransB || isConjTransB) ? ib : jb;
+			    int jy = (isTransA || isConjTransA) ? ia : ja;
+
+			    KokkosScalar prod = cij * y_dev(iy, jy);
+			    Kokkos::atomic_add(&x_dev(ix, jx), prod);
+		    });
+
+		// copy back and accumulate into xout
+
+		auto xhost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace {}, x_dev);
+		for (int ix = 0; ix < nrow_X; ++ix) {
+			for (int jx = 0; jx < ncol_X; ++jx)
+				xout(ix, jx) += static_cast<ComplexOrRealType>(xhost(ix, jx));
+		}
 	};
 }
 

--- a/dmrg/KronUtil/csr_kron_mult.cpp
+++ b/dmrg/KronUtil/csr_kron_mult.cpp
@@ -282,7 +282,6 @@ void csr_kron_mult_method(const int  imethod,
 		 * ---------------------------------------------
 		 */
 
-		// Build flat lists of nonzeros for A and B on the host, then copy to device
 		using ExecutionSpace = Kokkos::DefaultExecutionSpace;
 		using MemorySpace    = ExecutionSpace::memory_space;
 		using KokkosScalar   = typename PsimagLite::KokkosType<ComplexOrRealType>::type;
@@ -290,15 +289,18 @@ void csr_kron_mult_method(const int  imethod,
 		int nnzA = a.nonZeros();
 		int nnzB = b.nonZeros();
 
-		// create device views
 		Kokkos::View<int*, Kokkos::HostSpace> A_row_h(
-		    Kokkos::view_alloc(Kokkos::WithoutInitializing, "A_row_h"), nnzA);
+		    Kokkos::view_alloc(Kokkos::WithoutInitializing,
+		                       "PsimgLite:csr_kron_mult::imethod3::A_row_h"),
+		    nnzA);
 		Kokkos::View<const int*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged> A_col_h(
 		    &a.getCol(0), nnzA);
 		Kokkos::View<const KokkosScalar*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
 		    A_val_h(reinterpret_cast<const KokkosScalar*>(&a.getValue(0)), nnzA);
 		Kokkos::View<int*, Kokkos::HostSpace> B_row_h(
-		    Kokkos::view_alloc(Kokkos::WithoutInitializing, "B_row_h"), nnzB);
+		    Kokkos::view_alloc(Kokkos::WithoutInitializing,
+		                       "PsimgLite:csr_kron_mult::imethod3::B_row_h"),
+		    nnzB);
 		Kokkos::View<const int*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged> B_col_h(
 		    &b.getCol(0), nnzB);
 		Kokkos::View<const KokkosScalar*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>
@@ -306,9 +308,9 @@ void csr_kron_mult_method(const int  imethod,
 
 		{
 			Kokkos::Profiling::ScopedRegion region(
-			    "PsimgLite::csr_kron_mult_method::imethod3::fill_AB");
+			    "PsimgLite::csr_kron_mult_method::imethod3::store_rows");
 
-			// host-side temporary arrays
+			// store row for every entry
 			int idx = 0;
 			for (int ia = 0; ia < nrow_A; ++ia) {
 				int istart = a.getRowPtr(ia);
@@ -342,7 +344,6 @@ void csr_kron_mult_method(const int  imethod,
 		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), B_col_h);
 		auto B_val_dev = Kokkos::create_mirror_view_and_copy(
 		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), B_val_h);
-		// device yin and xout
 
 		auto yin_host = Kokkos::View<const KokkosScalar**,
 		                             Kokkos::LayoutLeft,
@@ -353,12 +354,11 @@ void csr_kron_mult_method(const int  imethod,
 		auto y_dev = Kokkos::create_mirror_view_and_copy(
 		    Kokkos::view_alloc(ExecutionSpace {}, MemorySpace {}), yin_host);
 
-		auto x_dev = Kokkos::View<KokkosScalar**>("x_dev", nrow_X, ncol_X);
-
-		const size_t totalPairs = static_cast<size_t>(nnzA) * static_cast<size_t>(nnzB);
+		auto x_dev = Kokkos::View<KokkosScalar**>(
+		    "PsimgLite:csr_kron_mult::imethod3::x_dev", nrow_X, ncol_X);
 
 		Kokkos::parallel_for(
-		    "csr_kron_mult::imethod3_pairs",
+		    "PsimgLite:csr_kron_mult::imethod3::spmv_kernel",
 		    Kokkos::MDRangePolicy<ExecutionSpace, Kokkos::Rank<2>>({ 0, 0 },
 		                                                           { nnzB, nnzA }),
 		    KOKKOS_LAMBDA(const size_t ib_idx, const size_t ia_idx) {
@@ -386,13 +386,16 @@ void csr_kron_mult_method(const int  imethod,
 			    KokkosScalar prod = cij * y_dev(iy, jy);
 			    Kokkos::atomic_add(&x_dev(ix, jx), prod);
 		    });
-
-		// copy back and accumulate into xout
-
-		auto xhost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace {}, x_dev);
-		for (int ix = 0; ix < nrow_X; ++ix) {
-			for (int jx = 0; jx < ncol_X; ++jx)
-				xout(ix, jx) += static_cast<ComplexOrRealType>(xhost(ix, jx));
+		{
+			Kokkos::Profiling::ScopedRegion region(
+			    "PsimgLite::csr_kron_mult_method::imethod3::copy_results");
+			auto xhost
+			    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace {}, x_dev);
+			for (int ix = 0; ix < nrow_X; ++ix) {
+				for (int jx = 0; jx < ncol_X; ++jx)
+					xout(ix, jx)
+					    += static_cast<ComplexOrRealType>(xhost(ix, jx));
+			}
 		}
 	};
 }


### PR DESCRIPTION
This pull request ports csr_kron_mult::imethod3 to Kokkos by using an MDRangePolicy implementation.

I tried a bunch of more elaborate implementations but it seems we are mostly just bound by launch latencyand exposing as much parallelism as possible is advantageous. For the 342 benchmark, I'm seeing on Frontier
```
4.88e+00 sec 6.8% 100.0% 0.0% ------ 205199 csr_kron_mult::imethod3_pairs [for]
```
vs
```
9.37e+00 sec 22.6% 0.0% 0.0% 0.0% 0.00e+00 205199 PsimgLite::csr_kron_mult_method::imethod3 [region]
```
before. All the other kernels introduced here don't seem to play a big role even on CPUs where the profile looks like
```
BEGIN KOKKOS PROFILING REPORT:
TOTAL TIME: 23.771507 seconds
TOP-DOWN TIME TREE:
<average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]
===================
|-> 1.25e+01 sec 52.7% 86.5% 0.0% 0.4% 3.30e+04 220232 PsimagLite::csr_kron_mult_method [region]
|   |-> 1.18e+01 sec 49.5% 92.0% 0.0% 5.5% 3.51e+04 206484 PsimgLite::csr_kron_mult_method::imethod3 [region]
|   |   |-> 1.08e+01 sec 45.3% 100.0% 0.0% ------ 206484 PsimgLite:csr_kron_mult::imethod3::spmv_kernel [for]
|   |   |-> 2.19e-01 sec 0.9% 0.0% 0.0% 100.0% 0.00e+00 206484 PsimgLite::csr_kron_mult_method::imethod3::copy_results [region]
|   |   |-> 7.29e-02 sec 0.3% 0.0% 0.0% 100.0% 0.00e+00 206484 PsimgLite::csr_kron_mult_method::imethod3::store_rows [region]
|   |   |-> 5.37e-02 sec 0.2% 100.0% 0.0% ------ 206484 Kokkos::View::initialization [PsimgLite:csr_kron_mult::imethod3::x_dev] via memset [for]
|   |-> 3.91e-01 sec 1.6% 0.0% 0.0% 100.0% 0.00e+00 8256 PsimgLite::csr_kron_mult_method::imethod2 [region]
|   |-> 3.09e-01 sec 1.3% 0.0% 0.0% 100.0% 0.00e+00 5492 PsimgLite::csr_kron_mult_method::imethod1 [region]
|-> 8.72e+00 sec 36.7% 99.4% 0.0% 0.4% 1.62e+04 70732 kokkos_gemm [region]
    |-> 8.67e+00 sec 36.5% 99.8% 0.0% 0.2% 7.23e+03 62673 KokkosBlas::gemm[ETI] [region]
    |   |-> 7.32e+00 sec 30.8% 100.0% 0.0% ------ 26647 KokkosBlas::gemm[NN] [for]
    |   |-> 8.01e-01 sec 3.4% 100.0% 0.0% ------ 23536 KokkosBlas::gemm[NT] [for]
    |   |-> 4.37e-01 sec 1.8% 100.0% 0.0% ------ 3996 KokkosBlas::gemm[CN] [for]
    |   |-> 9.64e-02 sec 0.4% 100.0% 0.0% ------ 8494 KokkosBlas::gemm[TN] [for]
```