### PR TITLE
Deletes Matrix::resize with three arguments

### DIFF
--- a/LanczosPlusPlus/src/Models/FeBasedSc/BasisOneSpinFeAs.h
+++ b/LanczosPlusPlus/src/Models/FeBasedSc/BasisOneSpinFeAs.h
@@ -318,7 +318,8 @@ private:
 	void doCombinatorial()
 	{
 		/* look-up table for binomial coefficients */
-		comb_.resize(orbitals_ * nsite_ + 1, orbitals_ * nsite_ + 1, 0);
+		comb_
+		    = PsimagLite::Matrix<SizeType>(orbitals_ * nsite_ + 1, orbitals_ * nsite_ + 1);
 
 		for (SizeType n = 0; n < comb_.n_row(); n++) {
 			SizeType m   = 0;

--- a/PsimagLite/examples/testLanczosMatrixInFile.cpp
+++ b/PsimagLite/examples/testLanczosMatrixInFile.cpp
@@ -21,9 +21,8 @@ int main(int argc, char** argv)
 	typedef PsimagLite::Vector<RealType>::Type      VectorRealType;
 	typedef PsimagLite::Vector<ComplexType>::Type   VectorType;
 
-	PsimagLite::Matrix<ComplexType> m;
-	std::ifstream                   fin(argv[1]);
-	PsimagLite::String              file(argv[1]);
+	std::ifstream      fin(argv[1]);
+	PsimagLite::String file(argv[1]);
 	if (!fin || fin.bad() || !fin.good())
 		throw PsimagLite::RuntimeError("Could not open file " + file + "\n");
 
@@ -34,7 +33,8 @@ int main(int argc, char** argv)
 	if (tmp != n)
 		throw PsimagLite::RuntimeError("Matrix in file " + file + " is not square\n");
 
-	m.resize(n, n, 0);
+	PsimagLite::Matrix<ComplexType> m(n, n);
+
 	for (SizeType i = 0; i < n; ++i)
 		for (SizeType j = 0; j < n; ++j)
 			fin >> m(i, j);

--- a/PsimagLite/src/PsimagLite/CrsMatrix.h
+++ b/PsimagLite/src/PsimagLite/CrsMatrix.h
@@ -711,12 +711,14 @@ template <typename S> void bcast(CrsMatrix<S>& m)
 //! Transforms a Compressed-Row-Storage (CRS) into a full Matrix (Fast version)
 template <typename T> void crsMatrixToFullMatrix(Matrix<T>& m, const CrsMatrix<T>& crsMatrix)
 {
-	m.resize(crsMatrix.rows(), crsMatrix.cols(), 0);
+	Matrix<T> temporary(crsMatrix.rows(), crsMatrix.cols());
 	for (SizeType i = 0; i < crsMatrix.rows(); i++) {
 		//  for (SizeType k=0;k<crsMatrix.cols();k++) m(i,k)=0;
 		for (int k = crsMatrix.getRowPtr(i); k < crsMatrix.getRowPtr(i + 1); k++)
-			m(i, crsMatrix.getCol(k)) = crsMatrix.getValue(k);
+			temporary(i, crsMatrix.getCol(k)) = crsMatrix.getValue(k);
 	}
+
+	m = std::move(temporary);
 }
 
 //! Transforms a full matrix into a Compressed-Row-Storage (CRS) Matrix

--- a/PsimagLite/src/PsimagLite/Matrix.h
+++ b/PsimagLite/src/PsimagLite/Matrix.h
@@ -266,27 +266,6 @@ public:
 		return (nrow_ == other.nrow_ && ncol_ == other.ncol_ && data_ == other.data_);
 	}
 
-	/*! \brief Reset this matrix to nrow x ncol, filled entirely with val.
-	 *
-	 * NOT element-preserving: existing entries are NOT reinterpreted at their
-	 * (row, col) position under the new shape. This resizes the flat
-	 * column-major backing store directly (data_[i + j*nrow_]), so if nrow
-	 * changes, a cell that reads as (row, col) after the call may hold
-	 * whatever was previously stored at a DIFFERENT (row, col) under the old
-	 * nrow_ -- e.g. shrinking from 12x12 to 8x8 leaves the new (0,1) holding
-	 * the old (8,0), not val and not the old (0,1). Safe uses: nrow is
-	 * unchanged, ncol is unchanged, or the matrix was empty beforehand (no
-	 * existing data to misinterpret). If you need old contents preserved (or
-	 * correctly zeroed) at their true (row, col) identity across a reshape
-	 * that changes nrow, use resize(nrow, ncol) instead.
-	 */
-	void resize(SizeType nrow, SizeType ncol, const T& val)
-	{
-		nrow_ = nrow;
-		ncol_ = ncol;
-		data_.resize(nrow * ncol, val);
-	}
-
 	/*! \brief Reshape this matrix to nrow x ncol, preserving existing data.
 	 *
 	 * Element-preserving and shape-aware: for every (i, j) that exists in

--- a/PsimagLite/src/PsimagLite/TridiagonalMatrix.h
+++ b/PsimagLite/src/PsimagLite/TridiagonalMatrix.h
@@ -146,11 +146,11 @@ public:
 	}
 
 	template <typename SomeMatrixType>
-	void buildDenseMatrix(SomeMatrixType& m, SizeType n = 0) const
+	void buildDenseMatrix(SomeMatrixType& m_dest, SizeType n = 0) const
 	{
 		if (n == 0)
 			n = a_.size();
-		m.resize(n, n, 0);
+		SomeMatrixType m(n, n);
 		for (SizeType i = 0; i < n - 1; ++i) {
 			m(i, i)     = a_[i];
 			m(i, i + 1) = b_[i + 1];
@@ -158,6 +158,8 @@ public:
 		}
 
 		m(n - 1, n - 1) = a_[n - 1];
+
+		m_dest = std::move(m);
 	}
 
 	void diag(VectorRealType& eigs, SizeType nn) const

--- a/PsimagLite/src/tests/test_Matrix.cpp
+++ b/PsimagLite/src/tests/test_Matrix.cpp
@@ -3,32 +3,6 @@
 
 using MatrixType = PsimagLite::Matrix<int>;
 
-// Locks down resize(nrow, ncol, val)'s documented contract: NOT
-// element-preserving across a change in nrow. Found via a real bug: a
-// process-lifetime cache (LanczosPlusPlus::Combinatorial) relied on this
-// overload leaving untouched cells at their old value across repeated
-// resizes to different sizes, and instead got a different, unrelated old
-// cell's value reinterpreted at the new (row, col) position.
-TEST_CASE("Matrix resize(nrow,ncol,val) is not element-preserving across nrow changes",
-          "[Matrix][resize]")
-{
-	MatrixType m(3, 3);
-	for (SizeType i = 0; i < 3; ++i)
-		for (SizeType j = 0; j < 3; ++j)
-			m(i, j) = static_cast<int>(10 * i + j);
-
-	// (0,1) is 1 before the resize.
-	CHECK(m(0, 1) == 1);
-
-	// Shrink to 2x2 with nrow changing (3 -> 2). Storage is column-major
-	// (flat index = i + j*nrow_), so this is a raw flat-array truncation,
-	// not a reshape: new (0,1)'s flat index is 0 + 1*2 = 2, which under
-	// the OLD nrow=3 layout was flat index 2, i.e. old (2,0) = 20 -- a
-	// cell unrelated to (0,1) by row/col identity.
-	m.resize(2, 2, -1);
-	CHECK(m(0, 1) == 20); // old (2,0), NOT the fill value -1 and NOT old (0,1)
-}
-
 // Locks down resize(nrow, ncol)'s documented contract: element-preserving
 // and shape-aware. Every (i,j) present in both shapes keeps its value;
 // newly-added (i,j) are value-initialized (0 for int). This is the

--- a/dmrg/Engine/BlockOffDiagMatrix.h
+++ b/dmrg/Engine/BlockOffDiagMatrix.h
@@ -20,39 +20,6 @@ public:
 
 	using value_type = MatrixBlockType;
 
-	template <typename SomeBasisType>
-	BlockOffDiagMatrix(const SomeBasisType&                  rowBasis,
-	                   const SomeBasisType&                  colBasis,
-	                   const typename SomeBasisType::QnType& qtarget)
-	{
-		using QnType        = typename SomeBasisType::VectorQnType::value_type;
-		SizeType rowPatches = rowBasis.partition();
-		offsetRows_.resize(rowPatches);
-		for (SizeType i = 0; i < rowPatches; ++i)
-			offsetRows_[i] = rowBasis.partition(i);
-		rows_ = offsetRows_[rowPatches - 1];
-
-		SizeType colPatches = colBasis.partition();
-		offsetCols_.resize(colPatches);
-		for (SizeType i = 0; i < colPatches; ++i)
-			offsetCols_[i] = colBasis.partition(i);
-		cols_ = offsetCols_[colPatches - 1];
-		data_.resize(rowPatches - 1, colPatches - 1, 0);
-
-		for (SizeType i = 0; i < rowPatches - 1; ++i) {
-			SizeType rows = offsetRows_[i + 1] - offsetRows_[i];
-			QnType   qrow = rowBasis.qnEx(i);
-			for (SizeType j = 0; j < colPatches - 1; ++j) {
-				QnType qcol = colBasis.qnEx(j);
-				QnType q(qrow, qcol);
-				if (q != qtarget)
-					continue;
-				SizeType cols = offsetCols_[j + 1] - offsetCols_[j];
-				data_(i, j)   = new MatrixBlockType(rows, cols);
-			}
-		}
-	}
-
 	BlockOffDiagMatrix(const SparseMatrixType& sparse, const VectorSizeType& partitions)
 	    : offsetRows_(partitions)
 	    , rows_(0)

--- a/dmrg/Engine/ObservableLibrary.h
+++ b/dmrg/Engine/ObservableLibrary.h
@@ -687,7 +687,7 @@ private:
 		}
 	}
 
-	void ppupupdndn(MatrixType& m,
+	void ppupupdndn(MatrixType& m1,
 	                MatrixType& m2,
 	                SizeType    orb1,
 	                SizeType    orb2,
@@ -699,15 +699,15 @@ private:
 			throw PsimagLite::RuntimeError(
 			    "ppFour: only string = 'two' or 'four' is allowed \n");
 		}
-		SizeType rows = m.n_row();
-		SizeType cols = m.n_col();
+		SizeType rows = m1.n_row();
+		SizeType cols = m1.n_col();
 		assert(rows == cols);
 		typename PsimagLite::Vector<PairSizeType>::Type pairs;
 		int                                             sign = 1;
 		VectorSizeType                                  gammas(1, 1 + sign);
 		SizeType                                        orbitals = 2;
-		SizeType bigSize = rows * orbitals * rows * orbitals * 2;
-		m.resize(bigSize, bigSize, static_cast<typename MatrixType::value_type>(0.0));
+		SizeType   bigSize = rows * orbitals * rows * orbitals * 2;
+		MatrixType m(bigSize, bigSize);
 
 		SizeType offset = (string == "four") ? orbitals : 1;
 		SizeType jmax   = (string == "four") ? cols - 1 : cols;
@@ -773,10 +773,8 @@ private:
 			}
 		}
 
-		m  = mup;
-		m2 = mdown;
-		// std::cout << mSinglet;
-		// std::cout << mTriplet;
+		m1 = std::move(mup);
+		m2 = std::move(mdown);
 	}
 
 	void ddOrbitalsTwopoint(typename PsimagLite::Vector<MatrixType*>::Type&        result,
@@ -1319,7 +1317,7 @@ private:
 		//		result.push_back(m1);
 	}
 
-	void ppFour(MatrixType&               m,
+	void ppFour(MatrixType&               m1,
 	            MatrixType&               m2,
 	            SizeType                  orb1,
 	            SizeType                  orb2,
@@ -1332,14 +1330,14 @@ private:
 			throw PsimagLite::RuntimeError(
 			    "ppFour: only string = 'two' or 'four' is allowed \n");
 		}
-		SizeType rows = m.n_row();
-		SizeType cols = m.n_col();
+		SizeType rows = m1.n_row();
+		SizeType cols = m1.n_col();
 		assert(rows == cols);
 		typename PsimagLite::Vector<PairSizeType>::Type pairs;
 		VectorSizeType                                  gammas(1, 1 + sign);
 		SizeType                                        orbitals = 2;
-		SizeType bigSize = rows * orbitals * rows * orbitals * 2;
-		m.resize(bigSize, bigSize, static_cast<typename MatrixType::value_type>(0.0));
+		SizeType   bigSize = rows * orbitals * rows * orbitals * 2;
+		MatrixType m(bigSize, bigSize);
 
 		SizeType offset = (string == "four") ? orbitals : 1;
 		SizeType jmax   = (string == "four") ? cols - 1 : cols;
@@ -1414,10 +1412,8 @@ private:
 			}
 		}
 
-		m  = mSinglet;
-		m2 = mTriplet;
-		// std::cout << mSinglet;
-		// std::cout << mTriplet;
+		m1 = std::move(mSinglet);
+		m2 = std::move(mTriplet);
 	}
 
 	void manyPoint(MatrixType*                storage,


### PR DESCRIPTION
This PR deletes member function Matrix::resize(rows, cols, val), because it's dangerous to use; see this https://github.com/dmrgpp-project/dmrgpp/pull/231 for explanation; PR #231 will be merged before this one.

The other resize(rows, cols) with two arguments remains, because it is safely implemented.