### PR TITLE
Check text and numbers

### DIFF
--- a/PsimagLite/examples/CMakeLists.txt
+++ b/PsimagLite/examples/CMakeLists.txt
@@ -24,6 +24,13 @@ add_executable(checkRunId checkRunId.cpp)
 target_link_libraries(checkRunId psimaglite)
 add_test(NAME checkRunId COMMAND checkRunId -g 4)
 
+add_executable(checkTextAndNumbers checkTextAndNumbers.cpp)
+target_link_libraries(checkTextAndNumbers PRIVATE Catch2::Catch2 psimaglite)
+add_test(
+  NAME checkTextAndNumbers
+  COMMAND checkTextAndNumbers ${CMAKE_CURRENT_SOURCE_DIR}/checkTextAndNumbers.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/checkTextAndNumbers.cpp 0.0)
+
 add_executable(closuresTest closuresTest.cpp)
 target_link_libraries(closuresTest psimaglite)
 add_test(NAME closuresTest COMMAND closuresTest)

--- a/PsimagLite/examples/CMakeLists.txt
+++ b/PsimagLite/examples/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(checkRunId psimaglite)
 add_test(NAME checkRunId COMMAND checkRunId -g 4)
 
 add_executable(checkTextAndNumbers checkTextAndNumbers.cpp)
-target_link_libraries(checkTextAndNumbers PRIVATE Catch2::Catch2 psimaglite)
+target_link_libraries(checkTextAndNumbers psimaglite)
 add_test(NAME checkTextAndNumbers COMMAND checkTextAndNumbers ${CMAKE_CURRENT_SOURCE_DIR}/checkTextAndNumbers.cpp
                                           ${CMAKE_CURRENT_SOURCE_DIR}/checkTextAndNumbers.cpp 0.0)
 

--- a/PsimagLite/examples/CMakeLists.txt
+++ b/PsimagLite/examples/CMakeLists.txt
@@ -26,10 +26,8 @@ add_test(NAME checkRunId COMMAND checkRunId -g 4)
 
 add_executable(checkTextAndNumbers checkTextAndNumbers.cpp)
 target_link_libraries(checkTextAndNumbers PRIVATE Catch2::Catch2 psimaglite)
-add_test(
-  NAME checkTextAndNumbers
-  COMMAND checkTextAndNumbers ${CMAKE_CURRENT_SOURCE_DIR}/checkTextAndNumbers.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/checkTextAndNumbers.cpp 0.0)
+add_test(NAME checkTextAndNumbers COMMAND checkTextAndNumbers ${CMAKE_CURRENT_SOURCE_DIR}/checkTextAndNumbers.cpp
+                                          ${CMAKE_CURRENT_SOURCE_DIR}/checkTextAndNumbers.cpp 0.0)
 
 add_executable(closuresTest closuresTest.cpp)
 target_link_libraries(closuresTest psimaglite)

--- a/PsimagLite/examples/checkTextAndNumbers.cpp
+++ b/PsimagLite/examples/checkTextAndNumbers.cpp
@@ -16,6 +16,16 @@ std::string file1;
 std::string file2;
 std::unique_ptr<PsimagLite::TextAndNumbersChecker> checker;
 
+std::string parseIgnoredLinePrefix(const char* text)
+{
+	const std::string argument(text);
+	const std::string option = "--ignore-line-prefix=";
+	if (argument.compare(0, option.size(), option) != 0 || argument.size() == option.size())
+		throw std::invalid_argument("Invalid option: \"" + argument + "\"");
+
+	return argument.substr(option.size());
+}
+
 double parseTolerance(const char* text)
 {
 	const std::string token(text);
@@ -42,15 +52,19 @@ TEST_CASE("text and numbers in two files match", "[TextAndNumbersChecker]")
 
 int main(int argc, char* argv[])
 {
-	if (argc != 4) {
-		std::cerr << "Usage: " << argv[0] << " FILE1 FILE2 TOLERANCE\n";
+	if (argc != 4 && argc != 5) {
+		std::cerr << "Usage: " << argv[0]
+		          << " FILE1 FILE2 TOLERANCE [--ignore-line-prefix=PREFIX]\n";
 		return EXIT_FAILURE;
 	}
 
 	try {
 		file1 = argv[1];
 		file2 = argv[2];
-		checker = std::make_unique<PsimagLite::TextAndNumbersChecker>(parseTolerance(argv[3]));
+		const std::string ignoredLinePrefix
+		    = (argc == 5) ? parseIgnoredLinePrefix(argv[4]) : "";
+		checker = std::make_unique<PsimagLite::TextAndNumbersChecker>(
+		    parseTolerance(argv[3]), ignoredLinePrefix);
 	} catch (const std::exception& error) {
 		std::cerr << error.what() << '\n';
 		return EXIT_FAILURE;

--- a/PsimagLite/examples/checkTextAndNumbers.cpp
+++ b/PsimagLite/examples/checkTextAndNumbers.cpp
@@ -12,8 +12,8 @@
 
 namespace {
 
-std::string file1;
-std::string file2;
+std::string                                        file1;
+std::string                                        file2;
 std::unique_ptr<PsimagLite::TextAndNumbersChecker> checker;
 
 std::string parseIgnoredLinePrefix(const char* text)
@@ -29,7 +29,7 @@ std::string parseIgnoredLinePrefix(const char* text)
 double parseTolerance(const char* text)
 {
 	const std::string token(text);
-	std::size_t parsed = 0;
+	std::size_t       parsed = 0;
 	try {
 		const double value = std::stod(token, &parsed);
 		if (parsed != token.size() || !std::isfinite(value))

--- a/PsimagLite/examples/checkTextAndNumbers.cpp
+++ b/PsimagLite/examples/checkTextAndNumbers.cpp
@@ -1,0 +1,61 @@
+#include <PsimagLite/TextAndNumbersChecker.hpp>
+
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+std::string file1;
+std::string file2;
+std::unique_ptr<PsimagLite::TextAndNumbersChecker> checker;
+
+double parseTolerance(const char* text)
+{
+	const std::string token(text);
+	std::size_t parsed = 0;
+	try {
+		const double value = std::stod(token, &parsed);
+		if (parsed != token.size() || !std::isfinite(value))
+			throw std::invalid_argument("not a finite real number");
+		return value;
+	} catch (const std::invalid_argument&) {
+		throw std::invalid_argument("Invalid tolerance: \"" + token + "\"");
+	} catch (const std::out_of_range&) {
+		throw std::invalid_argument("Tolerance is out of range: \"" + token + "\"");
+	}
+}
+
+} // namespace
+
+TEST_CASE("text and numbers in two files match", "[TextAndNumbersChecker]")
+{
+	REQUIRE(static_cast<bool>(checker));
+	REQUIRE_NOTHROW(checker->run(file1, file2));
+}
+
+int main(int argc, char* argv[])
+{
+	if (argc != 4) {
+		std::cerr << "Usage: " << argv[0] << " FILE1 FILE2 TOLERANCE\n";
+		return EXIT_FAILURE;
+	}
+
+	try {
+		file1 = argv[1];
+		file2 = argv[2];
+		checker = std::make_unique<PsimagLite::TextAndNumbersChecker>(parseTolerance(argv[3]));
+	} catch (const std::exception& error) {
+		std::cerr << error.what() << '\n';
+		return EXIT_FAILURE;
+	}
+
+	char* catchArguments[] = { argv[0] };
+	return Catch::Session().run(1, catchArguments);
+}

--- a/PsimagLite/examples/checkTextAndNumbers.cpp
+++ b/PsimagLite/examples/checkTextAndNumbers.cpp
@@ -1,8 +1,5 @@
 #include <PsimagLite/TextAndNumbersChecker.hpp>
 
-#include <catch2/catch_session.hpp>
-#include <catch2/catch_test_macros.hpp>
-
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
@@ -11,10 +8,6 @@
 #include <string>
 
 namespace {
-
-std::string                                        file1;
-std::string                                        file2;
-std::unique_ptr<PsimagLite::TextAndNumbersChecker> checker;
 
 std::string parseIgnoredLinePrefix(const char* text)
 {
@@ -44,12 +37,6 @@ double parseTolerance(const char* text)
 
 } // namespace
 
-TEST_CASE("text and numbers in two files match", "[TextAndNumbersChecker]")
-{
-	REQUIRE(static_cast<bool>(checker));
-	REQUIRE_NOTHROW(checker->run(file1, file2));
-}
-
 int main(int argc, char* argv[])
 {
 	if (argc != 4 && argc != 5) {
@@ -57,6 +44,10 @@ int main(int argc, char* argv[])
 		          << " FILE1 FILE2 TOLERANCE [--ignore-line-prefix=PREFIX]\n";
 		return EXIT_FAILURE;
 	}
+
+	std::string                                        file1;
+	std::string                                        file2;
+	std::unique_ptr<PsimagLite::TextAndNumbersChecker> checker;
 
 	try {
 		file1 = argv[1];
@@ -70,6 +61,5 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	char* catchArguments[] = { argv[0] };
-	return Catch::Session().run(1, catchArguments);
+	checker->run(file1, file2);
 }

--- a/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
+++ b/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
@@ -67,7 +67,7 @@ public:
 	 * 	hrows std::runtime_error if a file cannot be opened, a numeric token
 	 *         cannot be represented, or the file contents do not match
 	 */
-	void run(const std::string& file1, const std::string& file2) const
+	void run(const std::filesystem::path& file1, const std::filesystem::path& file2) const
 	{
 		std::ifstream stream1(file1);
 		if (!stream1)
@@ -128,7 +128,7 @@ private:
 		token.clear();
 		char c = 0;
 		while (stream.get(c)) {
-			if (!std::isspace(c)) {
+			if (!std::isspace(static_cast<unsigned char>(c))) {
 				token.push_back(c);
 				break;
 			}
@@ -138,7 +138,7 @@ private:
 			return false;
 
 		while (stream.get(c)) {
-			if (std::isspace(c))
+			if (std::isspace(static_cast<unsigned char>(c)))
 				break;
 			token.push_back(c);
 		}

--- a/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
+++ b/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
@@ -8,6 +8,7 @@
 #ifndef TEXT_AND_NUMBERS_CHECKER_HPP
 #define TEXT_AND_NUMBERS_CHECKER_HPP
 
+#include <cctype>
 #include <cmath>
 #include <cstddef>
 #include <fstream>
@@ -115,29 +116,6 @@ private:
 
 	//---------------------------------------------------------------------------//
 	/*!
-	 * \brief Determine whether a character is ASCII whitespace
-	 *
-	 * \param[in] c Character to classify
-	 *
-	 * \returns True for an ASCII whitespace character
-	 */
-	static bool isAsciiWhitespace(char c)
-	{
-		switch (c) {
-		case ' ':
-		case '\t':
-		case '\n':
-		case '\r':
-		case '\f':
-		case '\v':
-			return true;
-		default:
-			return false;
-		}
-	}
-
-	//---------------------------------------------------------------------------//
-	/*!
 	 * \brief Read the next ASCII-whitespace-delimited token from a stream
 	 *
 	 * \param[in/out] stream Stream from which to read
@@ -150,7 +128,7 @@ private:
 		token.clear();
 		char c = 0;
 		while (stream.get(c)) {
-			if (!isAsciiWhitespace(c)) {
+			if (!std::isspace(c)) {
 				token.push_back(c);
 				break;
 			}
@@ -160,7 +138,7 @@ private:
 			return false;
 
 		while (stream.get(c)) {
-			if (isAsciiWhitespace(c))
+			if (std::isspace(c))
 				break;
 			token.push_back(c);
 		}

--- a/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
+++ b/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
@@ -13,6 +13,7 @@ namespace PsimagLite {
 
 class TextAndNumbersChecker {
 public:
+
 	using RealType = double;
 
 	explicit TextAndNumbersChecker(RealType           tolerance,
@@ -21,7 +22,8 @@ public:
 	    , ignoredLinePrefix_(ignoredLinePrefix)
 	{
 		if (!std::isfinite(tolerance_) || tolerance_ < 0)
-			throw std::invalid_argument("The tolerance must be non-negative and finite");
+			throw std::invalid_argument(
+			    "The tolerance must be non-negative and finite");
 	}
 
 	void run(const std::string& file1, const std::string& file2) const
@@ -47,9 +49,14 @@ public:
 				return;
 
 			if (hasToken1 != hasToken2) {
-				const std::string shown1 = hasToken1 ? quote(token1) : "<end of file>";
-				const std::string shown2 = hasToken2 ? quote(token2) : "<end of file>";
-				fail(position, shown1, shown2, "the files contain different numbers of tokens");
+				const std::string shown1
+				    = hasToken1 ? quote(token1) : "<end of file>";
+				const std::string shown2
+				    = hasToken2 ? quote(token2) : "<end of file>";
+				fail(position,
+				     shown1,
+				     shown2,
+				     "the files contain different numbers of tokens");
 			}
 
 			compareTokens(token1, token2, position);
@@ -58,7 +65,13 @@ public:
 	}
 
 private:
-	enum class TokenClass { Word, Integer, Double };
+
+	enum class TokenClass
+	{
+		Word,
+		Integer,
+		Double
+	};
 
 	static bool isAsciiWhitespace(char c)
 	{
@@ -193,7 +206,7 @@ private:
 
 	void compareTokens(const std::string& token1,
 	                   const std::string& token2,
-	                   std::size_t position) const
+	                   std::size_t        position) const
 	{
 		const TokenClass class1 = classify(token1);
 		const TokenClass class2 = classify(token2);
@@ -210,18 +223,24 @@ private:
 			if (token1 != token2)
 				fail(position, quote(token1), quote(token2), "words differ");
 			return;
-		case TokenClass::Integer: {
+		case TokenClass::Integer:
+		{
 			const long long value1 = parseInteger(token1);
 			const long long value2 = parseInteger(token2);
 			if (value1 != value2)
-				fail(position, quote(token1), quote(token2), "integer values differ");
+				fail(position,
+				     quote(token1),
+				     quote(token2),
+				     "integer values differ");
 			return;
 		}
-		case TokenClass::Double: {
+		case TokenClass::Double:
+		{
 			const RealType value1 = parseDouble(token1);
 			const RealType value2 = parseDouble(token2);
 			if (!checkRealNumbers(value1, value2))
-				fail(position, quote(token1), quote(token2), "double values differ");
+				fail(
+				    position, quote(token1), quote(token2), "double values differ");
 			return;
 		}
 		}
@@ -234,13 +253,14 @@ private:
 
 	static std::string quote(const std::string& token) { return "\"" + token + "\""; }
 
-	[[noreturn]] static void fail(std::size_t position,
+	[[noreturn]] static void fail(std::size_t        position,
 	                              const std::string& token1,
 	                              const std::string& token2,
 	                              const std::string& reason)
 	{
 		throw std::runtime_error("Token " + std::to_string(position) + ": " + reason
-		                         + "; first file has " + token1 + ", second file has " + token2);
+		                         + "; first file has " + token1 + ", second file has "
+		                         + token2);
 	}
 
 	RealType    tolerance_;

--- a/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
+++ b/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
@@ -11,6 +11,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstddef>
+#include <filesystem>
 #include <fstream>
 #include <regex>
 #include <sstream>
@@ -71,11 +72,11 @@ public:
 	{
 		std::ifstream stream1(file1);
 		if (!stream1)
-			throw std::runtime_error("Cannot open first file: " + file1);
+			throw std::runtime_error("Cannot open first file: " + file1.string());
 
 		std::ifstream stream2(file2);
 		if (!stream2)
-			throw std::runtime_error("Cannot open second file: " + file2);
+			throw std::runtime_error("Cannot open second file: " + file2.string());
 
 		TokenReader reader1(stream1, ignoredLinePrefix_);
 		TokenReader reader2(stream2, ignoredLinePrefix_);

--- a/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
+++ b/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <fstream>
 #include <regex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -14,8 +15,10 @@ class TextAndNumbersChecker {
 public:
 	using RealType = double;
 
-	explicit TextAndNumbersChecker(RealType tolerance)
+	explicit TextAndNumbersChecker(RealType           tolerance,
+	                               const std::string& ignoredLinePrefix = "")
 	    : tolerance_(tolerance)
+	    , ignoredLinePrefix_(ignoredLinePrefix)
 	{
 		if (!std::isfinite(tolerance_) || tolerance_ < 0)
 			throw std::invalid_argument("The tolerance must be non-negative and finite");
@@ -31,12 +34,14 @@ public:
 		if (!stream2)
 			throw std::runtime_error("Cannot open second file: " + file2);
 
+		TokenReader reader1(stream1, ignoredLinePrefix_);
+		TokenReader reader2(stream2, ignoredLinePrefix_);
 		std::size_t position = 1;
 		for (;;) {
 			std::string token1;
 			std::string token2;
-			const bool hasToken1 = readToken(stream1, token1);
-			const bool hasToken2 = readToken(stream2, token2);
+			const bool  hasToken1 = reader1.read(token1);
+			const bool  hasToken2 = reader2.read(token2);
 
 			if (!hasToken1 && !hasToken2)
 				return;
@@ -92,6 +97,42 @@ private:
 
 		return true;
 	}
+
+	class TokenReader {
+	public:
+
+		TokenReader(std::istream& stream, const std::string& ignoredLinePrefix)
+		    : stream_(stream)
+		    , ignoredLinePrefix_(ignoredLinePrefix)
+		{ }
+
+		bool read(std::string& token)
+		{
+			for (;;) {
+				if (readToken(lineStream_, token))
+					return true;
+
+				if (!std::getline(stream_, line_))
+					return false;
+
+				if (!ignoredLinePrefix_.empty()
+				    && line_.compare(
+				           0, ignoredLinePrefix_.size(), ignoredLinePrefix_)
+				        == 0)
+					continue;
+
+				lineStream_.clear();
+				lineStream_.str(line_);
+			}
+		}
+
+	private:
+
+		std::istream&      stream_;
+		const std::string& ignoredLinePrefix_;
+		std::istringstream lineStream_;
+		std::string        line_;
+	};
 
 	static TokenClass classify(const std::string& token)
 	{
@@ -202,7 +243,8 @@ private:
 		                         + "; first file has " + token1 + ", second file has " + token2);
 	}
 
-	RealType tolerance_;
+	RealType    tolerance_;
+	std::string ignoredLinePrefix_;
 };
 
 } // namespace PsimagLite

--- a/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
+++ b/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
@@ -1,3 +1,10 @@
+//---------------------------------*-C++-*-----------------------------------//
+/*!
+ * \file   PsimagLite/TextAndNumbersChecker.hpp
+ * \brief  Compare text files containing words and numbers
+ */
+//---------------------------------------------------------------------------//
+
 #ifndef TEXT_AND_NUMBERS_CHECKER_HPP
 #define TEXT_AND_NUMBERS_CHECKER_HPP
 
@@ -11,11 +18,34 @@
 
 namespace PsimagLite {
 
+//===========================================================================//
+/*!
+ * \class TextAndNumbersChecker
+ *
+ * \brief Compare whitespace-separated words and numbers in two text files
+ *
+ * Words are compared verbatim, integers by value, and real numbers using an
+ * absolute tolerance. Tokens in corresponding positions must have the same
+ * class. Lines beginning with an optional prefix can be excluded from the
+ * comparison.
+ */
+//===========================================================================//
 class TextAndNumbersChecker {
 public:
 
 	using RealType = double;
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Constructor
+	 *
+	 * \param[in] tolerance          Maximum absolute difference allowed between
+	 *                               corresponding real-number tokens
+	 * \param[in] ignoredLinePrefix  Prefix identifying lines to omit; an empty
+	 *                               prefix enables strict comparison of all lines
+	 *
+	 * 	hrows std::invalid_argument if the tolerance is negative or non-finite
+	 */
 	explicit TextAndNumbersChecker(RealType           tolerance,
 	                               const std::string& ignoredLinePrefix = "")
 	    : tolerance_(tolerance)
@@ -26,6 +56,16 @@ public:
 			    "The tolerance must be non-negative and finite");
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Compare two text files token by token
+	 *
+	 * \param[in] file1 Path to the first file
+	 * \param[in] file2 Path to the second file
+	 *
+	 * 	hrows std::runtime_error if a file cannot be opened, a numeric token
+	 *         cannot be represented, or the file contents do not match
+	 */
 	void run(const std::string& file1, const std::string& file2) const
 	{
 		std::ifstream stream1(file1);
@@ -73,6 +113,14 @@ private:
 		Double
 	};
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Determine whether a character is ASCII whitespace
+	 *
+	 * \param[in] c Character to classify
+	 *
+	 * \returns True for an ASCII whitespace character
+	 */
 	static bool isAsciiWhitespace(char c)
 	{
 		switch (c) {
@@ -88,6 +136,15 @@ private:
 		}
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Read the next ASCII-whitespace-delimited token from a stream
+	 *
+	 * \param[in/out] stream Stream from which to read
+	 * \param[out] token     Token read from the stream
+	 *
+	 * \returns True if a token was read, or false at end of stream
+	 */
 	static bool readToken(std::istream& stream, std::string& token)
 	{
 		token.clear();
@@ -111,14 +168,35 @@ private:
 		return true;
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \class TokenReader
+	 *
+	 * \brief Read tokens while omitting lines with a configured prefix
+	 */
 	class TokenReader {
 	public:
 
+		//---------------------------------------------------------------------------//
+		/*!
+		 * \brief Constructor
+		 *
+		 * \param[in/out] stream           Stream from which to read
+		 * \param[in] ignoredLinePrefix    Prefix identifying lines to omit
+		 */
 		TokenReader(std::istream& stream, const std::string& ignoredLinePrefix)
 		    : stream_(stream)
 		    , ignoredLinePrefix_(ignoredLinePrefix)
 		{ }
 
+		//---------------------------------------------------------------------------//
+		/*!
+		 * \brief Read the next token from a non-ignored line
+		 *
+		 * \param[out] token Token read from the stream
+		 *
+		 * \returns True if a token was read, or false at end of stream
+		 */
 		bool read(std::string& token)
 		{
 			for (;;) {
@@ -147,6 +225,14 @@ private:
 		std::string        line_;
 	};
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Classify a token as a word, integer, or real number
+	 *
+	 * \param[in] token Token to classify
+	 *
+	 * \returns The token class
+	 */
 	static TokenClass classify(const std::string& token)
 	{
 		static const std::regex integerPattern(R"([+-]?[0-9]+)");
@@ -160,6 +246,14 @@ private:
 		return TokenClass::Word;
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Return a printable name for a token class
+	 *
+	 * \param[in] tokenClass Token class to name
+	 *
+	 * \returns A static string naming the token class
+	 */
 	static const char* className(TokenClass tokenClass)
 	{
 		switch (tokenClass) {
@@ -174,6 +268,15 @@ private:
 		return "unknown";
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Parse an integer token
+	 *
+	 * \param[in] token Token to parse
+	 *
+	 * \returns The represented integer value
+	 * 	hrows std::runtime_error if the token is invalid or out of range
+	 */
 	static long long parseInteger(const std::string& token)
 	{
 		std::size_t parsed = 0;
@@ -189,6 +292,15 @@ private:
 		}
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Parse a real-number token
+	 *
+	 * \param[in] token Token to parse
+	 *
+	 * \returns The represented finite real value
+	 * 	hrows std::runtime_error if the token is invalid, non-finite, or out of range
+	 */
 	static RealType parseDouble(const std::string& token)
 	{
 		std::size_t parsed = 0;
@@ -204,6 +316,16 @@ private:
 		}
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Compare two tokens and report a mismatch
+	 *
+	 * \param[in] token1   Token from the first file
+	 * \param[in] token2   Token from the second file
+	 * \param[in] position One-based token position
+	 *
+	 * 	hrows std::runtime_error if the token classes or values differ
+	 */
 	void compareTokens(const std::string& token1,
 	                   const std::string& token2,
 	                   std::size_t        position) const
@@ -246,13 +368,41 @@ private:
 		}
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Compare two real values using the configured absolute tolerance
+	 *
+	 * \param[in] value1 Value from the first file
+	 * \param[in] value2 Value from the second file
+	 *
+	 * \returns True if the absolute difference does not exceed the tolerance
+	 */
 	bool checkRealNumbers(RealType value1, RealType value2) const
 	{
 		return std::abs(value1 - value2) <= tolerance_;
 	}
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Enclose a token in double quotation marks
+	 *
+	 * \param[in] token Token to quote
+	 *
+	 * \returns The quoted token
+	 */
 	static std::string quote(const std::string& token) { return "\"" + token + "\""; }
 
+	//---------------------------------------------------------------------------//
+	/*!
+	 * \brief Throw a comparison-failure exception
+	 *
+	 * \param[in] position One-based token position
+	 * \param[in] token1   Display text for the first file's token
+	 * \param[in] token2   Display text for the second file's token
+	 * \param[in] reason   Explanation of the mismatch
+	 *
+	 * 	hrows std::runtime_error unconditionally
+	 */
 	[[noreturn]] static void fail(std::size_t        position,
 	                              const std::string& token1,
 	                              const std::string& token2,

--- a/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
+++ b/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
@@ -17,8 +17,8 @@ public:
 	explicit TextAndNumbersChecker(RealType tolerance)
 	    : tolerance_(tolerance)
 	{
-		if (!std::isfinite(tolerance_))
-			throw std::invalid_argument("The tolerance must be finite");
+		if (!std::isfinite(tolerance_) || tolerance_ < 0)
+			throw std::invalid_argument("The tolerance must be non-negative and finite");
 	}
 
 	void run(const std::string& file1, const std::string& file2) const
@@ -186,9 +186,9 @@ private:
 		}
 	}
 
-	bool checkRealNumbers(RealType, RealType) const
+	bool checkRealNumbers(RealType value1, RealType value2) const
 	{
-		throw std::logic_error("checkRealNumbers is not implemented");
+		return std::abs(value1 - value2) <= tolerance_;
 	}
 
 	static std::string quote(const std::string& token) { return "\"" + token + "\""; }

--- a/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
+++ b/PsimagLite/src/PsimagLite/TextAndNumbersChecker.hpp
@@ -1,0 +1,210 @@
+#ifndef TEXT_AND_NUMBERS_CHECKER_HPP
+#define TEXT_AND_NUMBERS_CHECKER_HPP
+
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <regex>
+#include <stdexcept>
+#include <string>
+
+namespace PsimagLite {
+
+class TextAndNumbersChecker {
+public:
+	using RealType = double;
+
+	explicit TextAndNumbersChecker(RealType tolerance)
+	    : tolerance_(tolerance)
+	{
+		if (!std::isfinite(tolerance_))
+			throw std::invalid_argument("The tolerance must be finite");
+	}
+
+	void run(const std::string& file1, const std::string& file2) const
+	{
+		std::ifstream stream1(file1);
+		if (!stream1)
+			throw std::runtime_error("Cannot open first file: " + file1);
+
+		std::ifstream stream2(file2);
+		if (!stream2)
+			throw std::runtime_error("Cannot open second file: " + file2);
+
+		std::size_t position = 1;
+		for (;;) {
+			std::string token1;
+			std::string token2;
+			const bool hasToken1 = readToken(stream1, token1);
+			const bool hasToken2 = readToken(stream2, token2);
+
+			if (!hasToken1 && !hasToken2)
+				return;
+
+			if (hasToken1 != hasToken2) {
+				const std::string shown1 = hasToken1 ? quote(token1) : "<end of file>";
+				const std::string shown2 = hasToken2 ? quote(token2) : "<end of file>";
+				fail(position, shown1, shown2, "the files contain different numbers of tokens");
+			}
+
+			compareTokens(token1, token2, position);
+			++position;
+		}
+	}
+
+private:
+	enum class TokenClass { Word, Integer, Double };
+
+	static bool isAsciiWhitespace(char c)
+	{
+		switch (c) {
+		case ' ':
+		case '\t':
+		case '\n':
+		case '\r':
+		case '\f':
+		case '\v':
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	static bool readToken(std::istream& stream, std::string& token)
+	{
+		token.clear();
+		char c = 0;
+		while (stream.get(c)) {
+			if (!isAsciiWhitespace(c)) {
+				token.push_back(c);
+				break;
+			}
+		}
+
+		if (token.empty())
+			return false;
+
+		while (stream.get(c)) {
+			if (isAsciiWhitespace(c))
+				break;
+			token.push_back(c);
+		}
+
+		return true;
+	}
+
+	static TokenClass classify(const std::string& token)
+	{
+		static const std::regex integerPattern(R"([+-]?[0-9]+)");
+		static const std::regex doublePattern(
+		    R"([+-]?(([0-9]+\.[0-9]*|\.[0-9]+)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+))");
+
+		if (std::regex_match(token, integerPattern))
+			return TokenClass::Integer;
+		if (std::regex_match(token, doublePattern))
+			return TokenClass::Double;
+		return TokenClass::Word;
+	}
+
+	static const char* className(TokenClass tokenClass)
+	{
+		switch (tokenClass) {
+		case TokenClass::Word:
+			return "word";
+		case TokenClass::Integer:
+			return "integer";
+		case TokenClass::Double:
+			return "double";
+		}
+
+		return "unknown";
+	}
+
+	static long long parseInteger(const std::string& token)
+	{
+		std::size_t parsed = 0;
+		try {
+			const long long value = std::stoll(token, &parsed, 10);
+			if (parsed != token.size())
+				throw std::runtime_error("Invalid integer token: " + quote(token));
+			return value;
+		} catch (const std::invalid_argument&) {
+			throw std::runtime_error("Invalid integer token: " + quote(token));
+		} catch (const std::out_of_range&) {
+			throw std::runtime_error("Integer token is out of range: " + quote(token));
+		}
+	}
+
+	static RealType parseDouble(const std::string& token)
+	{
+		std::size_t parsed = 0;
+		try {
+			const RealType value = std::stod(token, &parsed);
+			if (parsed != token.size() || !std::isfinite(value))
+				throw std::runtime_error("Invalid double token: " + quote(token));
+			return value;
+		} catch (const std::invalid_argument&) {
+			throw std::runtime_error("Invalid double token: " + quote(token));
+		} catch (const std::out_of_range&) {
+			throw std::runtime_error("Double token is out of range: " + quote(token));
+		}
+	}
+
+	void compareTokens(const std::string& token1,
+	                   const std::string& token2,
+	                   std::size_t position) const
+	{
+		const TokenClass class1 = classify(token1);
+		const TokenClass class2 = classify(token2);
+		if (class1 != class2) {
+			fail(position,
+			     quote(token1),
+			     quote(token2),
+			     std::string("different token classes (") + className(class1) + " and "
+			         + className(class2) + ")");
+		}
+
+		switch (class1) {
+		case TokenClass::Word:
+			if (token1 != token2)
+				fail(position, quote(token1), quote(token2), "words differ");
+			return;
+		case TokenClass::Integer: {
+			const long long value1 = parseInteger(token1);
+			const long long value2 = parseInteger(token2);
+			if (value1 != value2)
+				fail(position, quote(token1), quote(token2), "integer values differ");
+			return;
+		}
+		case TokenClass::Double: {
+			const RealType value1 = parseDouble(token1);
+			const RealType value2 = parseDouble(token2);
+			if (!checkRealNumbers(value1, value2))
+				fail(position, quote(token1), quote(token2), "double values differ");
+			return;
+		}
+		}
+	}
+
+	bool checkRealNumbers(RealType, RealType) const
+	{
+		throw std::logic_error("checkRealNumbers is not implemented");
+	}
+
+	static std::string quote(const std::string& token) { return "\"" + token + "\""; }
+
+	[[noreturn]] static void fail(std::size_t position,
+	                              const std::string& token1,
+	                              const std::string& token2,
+	                              const std::string& reason)
+	{
+		throw std::runtime_error("Token " + std::to_string(position) + ": " + reason
+		                         + "; first file has " + token1 + ", second file has " + token2);
+	}
+
+	RealType tolerance_;
+};
+
+} // namespace PsimagLite
+
+#endif // TEXT_AND_NUMBERS_CHECKER_HPP

--- a/PsimagLite/src/tests/CMakeLists.txt
+++ b/PsimagLite/src/tests/CMakeLists.txt
@@ -15,6 +15,10 @@ add_executable(test_InputPath test_InputPath.cpp)
 target_link_libraries(test_InputPath PRIVATE Catch2::Catch2WithMain psimaglite)
 catch_discover_tests(test_InputPath)
 
+add_executable(testCheckTextAndNumbers testCheckTextAndNumbers.cpp)
+target_link_libraries(testCheckTextAndNumbers PRIVATE Catch2::Catch2WithMain psimaglite)
+catch_discover_tests(testCheckTextAndNumbers)
+
 add_executable(test_GetBraOrKet test_GetBraOrKet.cpp)
 target_link_libraries(test_GetBraOrKet PRIVATE Catch2::Catch2WithMain psimaglite)
 catch_discover_tests(test_GetBraOrKet)

--- a/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
+++ b/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
@@ -275,6 +275,49 @@ TEST_CASE("TextAndNumbersChecker rejects negative tolerances", "[TextAndNumbersC
 	CHECK_THROWS_AS(TextAndNumbersChecker(-0.01), std::invalid_argument);
 }
 
+TEST_CASE("TextAndNumbersChecker ignores configured line prefixes", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles files;
+
+	SECTION("marked lines are ignored independently")
+	{
+		TextAndNumbersChecker checker(0.001, "##");
+		const auto            file1 = files.write(
+                    "first.txt", "## generated at 1.25 seconds\nword\n## first only\n1.0\n");
+		const auto file2
+		    = files.write("second.txt", "## generated at 9.75 seconds\nword\n1.0005\n");
+		CHECK_NOTHROW(checker.run(file1, file2));
+	}
+
+	SECTION("the marker must start at column one")
+	{
+		TextAndNumbersChecker checker(0.001, "##");
+		const auto            file1 = files.write("first.txt", " ## not ignored\nword\n");
+		const auto            file2 = files.write("second.txt", "word\n");
+		CHECK_THROWS(checker.run(file1, file2));
+	}
+
+	SECTION("a marker in the middle of a line is not ignored")
+	{
+		TextAndNumbersChecker checker(0.001, "##");
+		const auto            file1 = files.write("first.txt", "word ## first\n");
+		const auto            file2 = files.write("second.txt", "word ## second\n");
+		CHECK_THROWS_MATCHES(checker.run(file1, file2),
+		                     std::runtime_error,
+		                     MessageMatches(ContainsSubstring("Token 3: words differ")));
+	}
+
+	SECTION("strict comparison remains the default")
+	{
+		TextAndNumbersChecker checker(0.001);
+		const auto            file1 = files.write("first.txt", "## first\nword\n");
+		const auto            file2 = files.write("second.txt", "## second\nword\n");
+		CHECK_THROWS_MATCHES(checker.run(file1, file2),
+		                     std::runtime_error,
+		                     MessageMatches(ContainsSubstring("Token 2: words differ")));
+	}
+}
+
 TEST_CASE("TextAndNumbersChecker compares real numbers with absolute tolerance",
           "[TextAndNumbersChecker]")
 {

--- a/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
+++ b/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
@@ -37,7 +37,8 @@ namespace {
 			std::filesystem::remove_all(directory_, error);
 		}
 
-		std::string write(const std::string& name, const std::string& contents) const
+		std::filesystem::path write(const std::string& name,
+		                            const std::string& contents) const
 		{
 			const auto    path = directory_ / name;
 			std::ofstream stream(path, std::ios::binary);
@@ -51,12 +52,12 @@ namespace {
 				throw std::runtime_error("Cannot write test file: "
 				                         + path.string());
 
-			return path.string();
+			return path;
 		}
 
-		std::string path(const std::string& name) const
+		std::filesystem::path path(const std::string& name) const
 		{
-			return (directory_ / name).string();
+			return (directory_ / name);
 		}
 
 	private:
@@ -240,16 +241,16 @@ TEST_CASE("TextAndNumbersChecker reports files that cannot be opened", "[TextAnd
 	{
 		const auto missing = files.path("missing-first.txt");
 		const auto file2   = files.write("second.txt", "same");
-		CHECK_THROWS_WITH(checker.run(missing, file2),
-		                  "Cannot open first file: " + missing);
+		CHECK_THROWS_WITH(checker.run(missing.string(), file2.string()),
+		                  "Cannot open first file: " + missing.string());
 	}
 
 	SECTION("second file is missing")
 	{
 		const auto file1   = files.write("first.txt", "same");
 		const auto missing = files.path("missing-second.txt");
-		CHECK_THROWS_WITH(checker.run(file1, missing),
-		                  "Cannot open second file: " + missing);
+		CHECK_THROWS_WITH(checker.run(file1.string(), missing.string()),
+		                  "Cannot open second file: " + missing.string());
 	}
 }
 

--- a/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
+++ b/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
@@ -1,0 +1,284 @@
+#include <PsimagLite/TextAndNumbersChecker.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace PsimagLite {
+namespace {
+
+class TemporaryFiles {
+public:
+	TemporaryFiles()
+	{
+		static unsigned long counter = 0;
+		const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+		directory_ = std::filesystem::temp_directory_path()
+		    / ("psimaglite-text-checker-" + std::to_string(stamp) + "-"
+		       + std::to_string(counter++));
+		std::filesystem::create_directory(directory_);
+	}
+
+	~TemporaryFiles()
+	{
+		std::error_code error;
+		std::filesystem::remove_all(directory_, error);
+	}
+
+	std::string write(const std::string& name, const std::string& contents) const
+	{
+		const auto path = directory_ / name;
+		std::ofstream stream(path, std::ios::binary);
+		if (!stream)
+			throw std::runtime_error("Cannot create test file: " + path.string());
+
+		stream.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+		if (!stream)
+			throw std::runtime_error("Cannot write test file: " + path.string());
+
+		return path.string();
+	}
+
+	std::string path(const std::string& name) const { return (directory_ / name).string(); }
+
+private:
+	std::filesystem::path directory_;
+};
+
+using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::MessageMatches;
+
+} // namespace
+
+TEST_CASE("TextAndNumbersChecker accepts empty files", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+	const auto            file1 = files.write("first.txt", "");
+	const auto            file2 = files.write("second.txt", "");
+
+	CHECK_NOTHROW(checker.run(file1, file2));
+}
+
+TEST_CASE("TextAndNumbersChecker compares words verbatim", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+
+	SECTION("identical words match")
+	{
+		const auto file1 = files.write("first.txt", "Alpha beta word,");
+		const auto file2 = files.write("second.txt", "Alpha beta word,");
+		CHECK_NOTHROW(checker.run(file1, file2));
+	}
+
+	SECTION("case differences fail")
+	{
+		const auto file1 = files.write("first.txt", "Word");
+		const auto file2 = files.write("second.txt", "word");
+		CHECK_THROWS_WITH(checker.run(file1, file2),
+		                  "Token 1: words differ; first file has \"Word\", second file has \"word\"");
+	}
+
+	SECTION("punctuation differences fail")
+	{
+		const auto file1 = files.write("first.txt", "word,");
+		const auto file2 = files.write("second.txt", "word");
+		CHECK_THROWS_WITH(checker.run(file1, file2),
+		                  "Token 1: words differ; first file has \"word,\", second file has \"word\"");
+	}
+}
+
+TEST_CASE("TextAndNumbersChecker recognizes every ASCII whitespace", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+	const auto file1 = files.write("first.txt", "one two\tthree\nfour\rfive\fsix\vseven");
+	const auto file2 = files.write("second.txt", "one\ttwo three\rfour\nfive\vsix\fseven");
+
+	CHECK_NOTHROW(checker.run(file1, file2));
+}
+
+TEST_CASE("TextAndNumbersChecker compares parsed integers", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+
+	SECTION("equivalent representations match")
+	{
+		const auto file1 = files.write("first.txt", "03 +3 -0 -0042");
+		const auto file2 = files.write("second.txt", "3 3 0 -42");
+		CHECK_NOTHROW(checker.run(file1, file2));
+	}
+
+	SECTION("different values fail")
+	{
+		const auto file1 = files.write("first.txt", "same 3");
+		const auto file2 = files.write("second.txt", "same 4");
+		CHECK_THROWS_WITH(checker.run(file1, file2),
+		                  "Token 2: integer values differ; first file has \"3\", second file has \"4\"");
+	}
+}
+
+TEST_CASE("TextAndNumbersChecker rejects different token classes", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+	const auto            file1 = files.write("first.txt", "3");
+	const auto            file2 = files.write("second.txt", "3.0");
+
+	CHECK_THROWS_WITH(
+	    checker.run(file1, file2),
+	    "Token 1: different token classes (integer and double); first file has \"3\", second file has \"3.0\"");
+}
+
+TEST_CASE("TextAndNumbersChecker recognizes strict double syntax", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+	const std::vector<std::string> doubles { "3.0", ".5", "5.", "1e3", "-2.5e-4" };
+
+	for (const auto& token : doubles) {
+		CAPTURE(token);
+		const auto file1 = files.write("first.txt", token);
+		const auto file2 = files.write("second.txt", token);
+		CHECK_THROWS_WITH(checker.run(file1, file2), "checkRealNumbers is not implemented");
+	}
+}
+
+TEST_CASE("TextAndNumbersChecker treats malformed numeric tokens as words",
+          "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+
+	SECTION("identical tokens match")
+	{
+		const auto file1 = files.write("first.txt", "1e . + 3.0suffix");
+		const auto file2 = files.write("second.txt", "1e . + 3.0suffix");
+		CHECK_NOTHROW(checker.run(file1, file2));
+	}
+
+	SECTION("different tokens fail as words")
+	{
+		const auto file1 = files.write("first.txt", "1e . + 3.0suffix");
+		const auto file2 = files.write("second.txt", "1e . + 4.0suffix");
+		CHECK_THROWS_MATCHES(checker.run(file1, file2),
+		                     std::runtime_error,
+		                     MessageMatches(ContainsSubstring("Token 4: words differ")));
+	}
+}
+
+TEST_CASE("TextAndNumbersChecker detects unequal token counts", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+
+	SECTION("first file is longer")
+	{
+		const auto file1 = files.write("first.txt", "one two");
+		const auto file2 = files.write("second.txt", "one");
+		CHECK_THROWS_MATCHES(checker.run(file1, file2),
+		                     std::runtime_error,
+		                     MessageMatches(ContainsSubstring(
+		                         "Token 2: the files contain different numbers of tokens")));
+	}
+
+	SECTION("second file is longer")
+	{
+		const auto file1 = files.write("first.txt", "one");
+		const auto file2 = files.write("second.txt", "one two");
+		CHECK_THROWS_MATCHES(checker.run(file1, file2),
+		                     std::runtime_error,
+		                     MessageMatches(ContainsSubstring(
+		                         "Token 2: the files contain different numbers of tokens")));
+	}
+}
+
+TEST_CASE("TextAndNumbersChecker stops at the first mismatch", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+	const auto            file1 = files.write("first.txt", "same first third");
+	const auto            file2 = files.write("second.txt", "same second fourth");
+
+	CHECK_THROWS_WITH(
+	    checker.run(file1, file2),
+	    "Token 2: words differ; first file has \"first\", second file has \"second\"");
+}
+
+TEST_CASE("TextAndNumbersChecker reports files that cannot be opened", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+
+	SECTION("first file is missing")
+	{
+		const auto missing = files.path("missing-first.txt");
+		const auto file2   = files.write("second.txt", "same");
+		CHECK_THROWS_WITH(checker.run(missing, file2), "Cannot open first file: " + missing);
+	}
+
+	SECTION("second file is missing")
+	{
+		const auto file1   = files.write("first.txt", "same");
+		const auto missing = files.path("missing-second.txt");
+		CHECK_THROWS_WITH(checker.run(file1, missing), "Cannot open second file: " + missing);
+	}
+}
+
+TEST_CASE("TextAndNumbersChecker reports integer overflow", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+	const std::string     value = "999999999999999999999999999999999999";
+	const auto            file1 = files.write("first.txt", value);
+	const auto            file2 = files.write("second.txt", value);
+
+	CHECK_THROWS_WITH(checker.run(file1, file2),
+	                  "Integer token is out of range: \"" + value + "\"");
+}
+
+TEST_CASE("TextAndNumbersChecker reports double overflow", "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+	const auto            file1 = files.write("first.txt", "1e9999");
+	const auto            file2 = files.write("second.txt", "1e9999");
+
+	CHECK_THROWS_WITH(checker.run(file1, file2),
+	                  "Double token is out of range: \"1e9999\"");
+}
+
+TEST_CASE("TextAndNumbersChecker rejects non-finite tolerances", "[TextAndNumbersChecker]")
+{
+	CHECK_THROWS_AS(TextAndNumbersChecker(std::numeric_limits<double>::infinity()),
+	                std::invalid_argument);
+	CHECK_THROWS_AS(TextAndNumbersChecker(-std::numeric_limits<double>::infinity()),
+	                std::invalid_argument);
+	CHECK_THROWS_AS(TextAndNumbersChecker(std::numeric_limits<double>::quiet_NaN()),
+	                std::invalid_argument);
+}
+
+TEST_CASE("TextAndNumbersChecker real-number comparison is unimplemented",
+          "[TextAndNumbersChecker]")
+{
+	TemporaryFiles       files;
+	TextAndNumbersChecker checker(0.01);
+	const auto            file1 = files.write("first.txt", "1.0");
+	const auto            file2 = files.write("second.txt", "1.0");
+
+	CHECK_THROWS_WITH(checker.run(file1, file2), "checkRealNumbers is not implemented");
+}
+
+} // namespace PsimagLite

--- a/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
+++ b/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
@@ -241,7 +241,7 @@ TEST_CASE("TextAndNumbersChecker reports files that cannot be opened", "[TextAnd
 	{
 		const auto missing = files.path("missing-first.txt");
 		const auto file2   = files.write("second.txt", "same");
-		CHECK_THROWS_WITH(checker.run(missing.string(), file2.string()),
+		CHECK_THROWS_WITH(checker.run(missing, file2),
 		                  "Cannot open first file: " + missing.string());
 	}
 
@@ -249,7 +249,7 @@ TEST_CASE("TextAndNumbersChecker reports files that cannot be opened", "[TextAnd
 	{
 		const auto file1   = files.write("first.txt", "same");
 		const auto missing = files.path("missing-second.txt");
-		CHECK_THROWS_WITH(checker.run(file1.string(), missing.string()),
+		CHECK_THROWS_WITH(checker.run(file1, missing),
 		                  "Cannot open second file: " + missing.string());
 	}
 }

--- a/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
+++ b/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
@@ -152,7 +152,7 @@ TEST_CASE("TextAndNumbersChecker recognizes strict double syntax", "[TextAndNumb
 		CAPTURE(token);
 		const auto file1 = files.write("first.txt", token);
 		const auto file2 = files.write("second.txt", token);
-		CHECK_THROWS_WITH(checker.run(file1, file2), "checkRealNumbers is not implemented");
+		CHECK_NOTHROW(checker.run(file1, file2));
 	}
 }
 
@@ -270,15 +270,57 @@ TEST_CASE("TextAndNumbersChecker rejects non-finite tolerances", "[TextAndNumber
 	                std::invalid_argument);
 }
 
-TEST_CASE("TextAndNumbersChecker real-number comparison is unimplemented",
+TEST_CASE("TextAndNumbersChecker rejects negative tolerances", "[TextAndNumbersChecker]")
+{
+	CHECK_THROWS_AS(TextAndNumbersChecker(-0.01), std::invalid_argument);
+}
+
+TEST_CASE("TextAndNumbersChecker compares real numbers with absolute tolerance",
           "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
-	TextAndNumbersChecker checker(0.01);
-	const auto            file1 = files.write("first.txt", "1.0");
-	const auto            file2 = files.write("second.txt", "1.0");
+	TemporaryFiles files;
 
-	CHECK_THROWS_WITH(checker.run(file1, file2), "checkRealNumbers is not implemented");
+	SECTION("equal values match")
+	{
+		TextAndNumbersChecker checker(0.0);
+		const auto file1 = files.write("first.txt", "1.0");
+		const auto file2 = files.write("second.txt", "1.0");
+		CHECK_NOTHROW(checker.run(file1, file2));
+	}
+
+	SECTION("a difference smaller than the tolerance matches")
+	{
+		TextAndNumbersChecker checker(0.125);
+		const auto file1 = files.write("first.txt", "-1.0");
+		const auto file2 = files.write("second.txt", "-1.0625");
+		CHECK_NOTHROW(checker.run(file1, file2));
+	}
+
+	SECTION("a difference equal to the tolerance matches")
+	{
+		TextAndNumbersChecker checker(0.125);
+		const auto file1 = files.write("first.txt", "1.0");
+		const auto file2 = files.write("second.txt", "1.125");
+		CHECK_NOTHROW(checker.run(file1, file2));
+	}
+
+	SECTION("a difference larger than the tolerance fails")
+	{
+		TextAndNumbersChecker checker(0.125);
+		const auto file1 = files.write("first.txt", "1.0");
+		const auto file2 = files.write("second.txt", "1.25");
+		CHECK_THROWS_WITH(
+		    checker.run(file1, file2),
+		    "Token 1: double values differ; first file has \"1.0\", second file has \"1.25\"");
+	}
+
+	SECTION("exponent notation uses parsed values")
+	{
+		TextAndNumbersChecker checker(0.125);
+		const auto file1 = files.write("first.txt", "1e3");
+		const auto file2 = files.write("second.txt", "1000.125");
+		CHECK_NOTHROW(checker.run(file1, file2));
+	}
 }
 
 } // namespace PsimagLite

--- a/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
+++ b/PsimagLite/src/tests/testCheckTextAndNumbers.cpp
@@ -17,52 +17,61 @@
 namespace PsimagLite {
 namespace {
 
-class TemporaryFiles {
-public:
-	TemporaryFiles()
-	{
-		static unsigned long counter = 0;
-		const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
-		directory_ = std::filesystem::temp_directory_path()
-		    / ("psimaglite-text-checker-" + std::to_string(stamp) + "-"
-		       + std::to_string(counter++));
-		std::filesystem::create_directory(directory_);
-	}
+	class TemporaryFiles {
+	public:
 
-	~TemporaryFiles()
-	{
-		std::error_code error;
-		std::filesystem::remove_all(directory_, error);
-	}
+		TemporaryFiles()
+		{
+			static unsigned long counter = 0;
+			const auto           stamp
+			    = std::chrono::steady_clock::now().time_since_epoch().count();
+			directory_ = std::filesystem::temp_directory_path()
+			    / ("psimaglite-text-checker-" + std::to_string(stamp) + "-"
+			       + std::to_string(counter++));
+			std::filesystem::create_directory(directory_);
+		}
 
-	std::string write(const std::string& name, const std::string& contents) const
-	{
-		const auto path = directory_ / name;
-		std::ofstream stream(path, std::ios::binary);
-		if (!stream)
-			throw std::runtime_error("Cannot create test file: " + path.string());
+		~TemporaryFiles()
+		{
+			std::error_code error;
+			std::filesystem::remove_all(directory_, error);
+		}
 
-		stream.write(contents.data(), static_cast<std::streamsize>(contents.size()));
-		if (!stream)
-			throw std::runtime_error("Cannot write test file: " + path.string());
+		std::string write(const std::string& name, const std::string& contents) const
+		{
+			const auto    path = directory_ / name;
+			std::ofstream stream(path, std::ios::binary);
+			if (!stream)
+				throw std::runtime_error("Cannot create test file: "
+				                         + path.string());
 
-		return path.string();
-	}
+			stream.write(contents.data(),
+			             static_cast<std::streamsize>(contents.size()));
+			if (!stream)
+				throw std::runtime_error("Cannot write test file: "
+				                         + path.string());
 
-	std::string path(const std::string& name) const { return (directory_ / name).string(); }
+			return path.string();
+		}
 
-private:
-	std::filesystem::path directory_;
-};
+		std::string path(const std::string& name) const
+		{
+			return (directory_ / name).string();
+		}
 
-using Catch::Matchers::ContainsSubstring;
-using Catch::Matchers::MessageMatches;
+	private:
+
+		std::filesystem::path directory_;
+	};
+
+	using Catch::Matchers::ContainsSubstring;
+	using Catch::Matchers::MessageMatches;
 
 } // namespace
 
 TEST_CASE("TextAndNumbersChecker accepts empty files", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 	const auto            file1 = files.write("first.txt", "");
 	const auto            file2 = files.write("second.txt", "");
@@ -72,7 +81,7 @@ TEST_CASE("TextAndNumbersChecker accepts empty files", "[TextAndNumbersChecker]"
 
 TEST_CASE("TextAndNumbersChecker compares words verbatim", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 
 	SECTION("identical words match")
@@ -86,22 +95,24 @@ TEST_CASE("TextAndNumbersChecker compares words verbatim", "[TextAndNumbersCheck
 	{
 		const auto file1 = files.write("first.txt", "Word");
 		const auto file2 = files.write("second.txt", "word");
-		CHECK_THROWS_WITH(checker.run(file1, file2),
-		                  "Token 1: words differ; first file has \"Word\", second file has \"word\"");
+		CHECK_THROWS_WITH(
+		    checker.run(file1, file2),
+		    "Token 1: words differ; first file has \"Word\", second file has \"word\"");
 	}
 
 	SECTION("punctuation differences fail")
 	{
 		const auto file1 = files.write("first.txt", "word,");
 		const auto file2 = files.write("second.txt", "word");
-		CHECK_THROWS_WITH(checker.run(file1, file2),
-		                  "Token 1: words differ; first file has \"word,\", second file has \"word\"");
+		CHECK_THROWS_WITH(
+		    checker.run(file1, file2),
+		    "Token 1: words differ; first file has \"word,\", second file has \"word\"");
 	}
 }
 
 TEST_CASE("TextAndNumbersChecker recognizes every ASCII whitespace", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 	const auto file1 = files.write("first.txt", "one two\tthree\nfour\rfive\fsix\vseven");
 	const auto file2 = files.write("second.txt", "one\ttwo three\rfour\nfive\vsix\fseven");
@@ -111,7 +122,7 @@ TEST_CASE("TextAndNumbersChecker recognizes every ASCII whitespace", "[TextAndNu
 
 TEST_CASE("TextAndNumbersChecker compares parsed integers", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 
 	SECTION("equivalent representations match")
@@ -125,27 +136,28 @@ TEST_CASE("TextAndNumbersChecker compares parsed integers", "[TextAndNumbersChec
 	{
 		const auto file1 = files.write("first.txt", "same 3");
 		const auto file2 = files.write("second.txt", "same 4");
-		CHECK_THROWS_WITH(checker.run(file1, file2),
-		                  "Token 2: integer values differ; first file has \"3\", second file has \"4\"");
+		CHECK_THROWS_WITH(
+		    checker.run(file1, file2),
+		    "Token 2: integer values differ; first file has \"3\", second file has \"4\"");
 	}
 }
 
 TEST_CASE("TextAndNumbersChecker rejects different token classes", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 	const auto            file1 = files.write("first.txt", "3");
 	const auto            file2 = files.write("second.txt", "3.0");
 
-	CHECK_THROWS_WITH(
-	    checker.run(file1, file2),
-	    "Token 1: different token classes (integer and double); first file has \"3\", second file has \"3.0\"");
+	CHECK_THROWS_WITH(checker.run(file1, file2),
+	                  "Token 1: different token classes (integer and double); first file has "
+	                  "\"3\", second file has \"3.0\"");
 }
 
 TEST_CASE("TextAndNumbersChecker recognizes strict double syntax", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
-	TextAndNumbersChecker checker(0.01);
+	TemporaryFiles                 files;
+	TextAndNumbersChecker          checker(0.01);
 	const std::vector<std::string> doubles { "3.0", ".5", "5.", "1e3", "-2.5e-4" };
 
 	for (const auto& token : doubles) {
@@ -159,7 +171,7 @@ TEST_CASE("TextAndNumbersChecker recognizes strict double syntax", "[TextAndNumb
 TEST_CASE("TextAndNumbersChecker treats malformed numeric tokens as words",
           "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 
 	SECTION("identical tokens match")
@@ -181,33 +193,35 @@ TEST_CASE("TextAndNumbersChecker treats malformed numeric tokens as words",
 
 TEST_CASE("TextAndNumbersChecker detects unequal token counts", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 
 	SECTION("first file is longer")
 	{
 		const auto file1 = files.write("first.txt", "one two");
 		const auto file2 = files.write("second.txt", "one");
-		CHECK_THROWS_MATCHES(checker.run(file1, file2),
-		                     std::runtime_error,
-		                     MessageMatches(ContainsSubstring(
-		                         "Token 2: the files contain different numbers of tokens")));
+		CHECK_THROWS_MATCHES(
+		    checker.run(file1, file2),
+		    std::runtime_error,
+		    MessageMatches(ContainsSubstring(
+		        "Token 2: the files contain different numbers of tokens")));
 	}
 
 	SECTION("second file is longer")
 	{
 		const auto file1 = files.write("first.txt", "one");
 		const auto file2 = files.write("second.txt", "one two");
-		CHECK_THROWS_MATCHES(checker.run(file1, file2),
-		                     std::runtime_error,
-		                     MessageMatches(ContainsSubstring(
-		                         "Token 2: the files contain different numbers of tokens")));
+		CHECK_THROWS_MATCHES(
+		    checker.run(file1, file2),
+		    std::runtime_error,
+		    MessageMatches(ContainsSubstring(
+		        "Token 2: the files contain different numbers of tokens")));
 	}
 }
 
 TEST_CASE("TextAndNumbersChecker stops at the first mismatch", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 	const auto            file1 = files.write("first.txt", "same first third");
 	const auto            file2 = files.write("second.txt", "same second fourth");
@@ -219,27 +233,29 @@ TEST_CASE("TextAndNumbersChecker stops at the first mismatch", "[TextAndNumbersC
 
 TEST_CASE("TextAndNumbersChecker reports files that cannot be opened", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 
 	SECTION("first file is missing")
 	{
 		const auto missing = files.path("missing-first.txt");
 		const auto file2   = files.write("second.txt", "same");
-		CHECK_THROWS_WITH(checker.run(missing, file2), "Cannot open first file: " + missing);
+		CHECK_THROWS_WITH(checker.run(missing, file2),
+		                  "Cannot open first file: " + missing);
 	}
 
 	SECTION("second file is missing")
 	{
 		const auto file1   = files.write("first.txt", "same");
 		const auto missing = files.path("missing-second.txt");
-		CHECK_THROWS_WITH(checker.run(file1, missing), "Cannot open second file: " + missing);
+		CHECK_THROWS_WITH(checker.run(file1, missing),
+		                  "Cannot open second file: " + missing);
 	}
 }
 
 TEST_CASE("TextAndNumbersChecker reports integer overflow", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 	const std::string     value = "999999999999999999999999999999999999";
 	const auto            file1 = files.write("first.txt", value);
@@ -251,13 +267,12 @@ TEST_CASE("TextAndNumbersChecker reports integer overflow", "[TextAndNumbersChec
 
 TEST_CASE("TextAndNumbersChecker reports double overflow", "[TextAndNumbersChecker]")
 {
-	TemporaryFiles       files;
+	TemporaryFiles        files;
 	TextAndNumbersChecker checker(0.01);
 	const auto            file1 = files.write("first.txt", "1e9999");
 	const auto            file2 = files.write("second.txt", "1e9999");
 
-	CHECK_THROWS_WITH(checker.run(file1, file2),
-	                  "Double token is out of range: \"1e9999\"");
+	CHECK_THROWS_WITH(checker.run(file1, file2), "Double token is out of range: \"1e9999\"");
 }
 
 TEST_CASE("TextAndNumbersChecker rejects non-finite tolerances", "[TextAndNumbersChecker]")
@@ -326,42 +341,42 @@ TEST_CASE("TextAndNumbersChecker compares real numbers with absolute tolerance",
 	SECTION("equal values match")
 	{
 		TextAndNumbersChecker checker(0.0);
-		const auto file1 = files.write("first.txt", "1.0");
-		const auto file2 = files.write("second.txt", "1.0");
+		const auto            file1 = files.write("first.txt", "1.0");
+		const auto            file2 = files.write("second.txt", "1.0");
 		CHECK_NOTHROW(checker.run(file1, file2));
 	}
 
 	SECTION("a difference smaller than the tolerance matches")
 	{
 		TextAndNumbersChecker checker(0.125);
-		const auto file1 = files.write("first.txt", "-1.0");
-		const auto file2 = files.write("second.txt", "-1.0625");
+		const auto            file1 = files.write("first.txt", "-1.0");
+		const auto            file2 = files.write("second.txt", "-1.0625");
 		CHECK_NOTHROW(checker.run(file1, file2));
 	}
 
 	SECTION("a difference equal to the tolerance matches")
 	{
 		TextAndNumbersChecker checker(0.125);
-		const auto file1 = files.write("first.txt", "1.0");
-		const auto file2 = files.write("second.txt", "1.125");
+		const auto            file1 = files.write("first.txt", "1.0");
+		const auto            file2 = files.write("second.txt", "1.125");
 		CHECK_NOTHROW(checker.run(file1, file2));
 	}
 
 	SECTION("a difference larger than the tolerance fails")
 	{
 		TextAndNumbersChecker checker(0.125);
-		const auto file1 = files.write("first.txt", "1.0");
-		const auto file2 = files.write("second.txt", "1.25");
-		CHECK_THROWS_WITH(
-		    checker.run(file1, file2),
-		    "Token 1: double values differ; first file has \"1.0\", second file has \"1.25\"");
+		const auto            file1 = files.write("first.txt", "1.0");
+		const auto            file2 = files.write("second.txt", "1.25");
+		CHECK_THROWS_WITH(checker.run(file1, file2),
+		                  "Token 1: double values differ; first file has \"1.0\", second "
+		                  "file has \"1.25\"");
 	}
 
 	SECTION("exponent notation uses parsed values")
 	{
 		TextAndNumbersChecker checker(0.125);
-		const auto file1 = files.write("first.txt", "1e3");
-		const auto file2 = files.write("second.txt", "1000.125");
+		const auto            file1 = files.write("first.txt", "1e3");
+		const auto            file2 = files.write("second.txt", "1000.125");
 		CHECK_NOTHROW(checker.run(file1, file2));
 	}
 }


### PR DESCRIPTION
TextCheckAndNumbers will be used to test the KronLogger as a full pipeline test, and introspect, and other things that require full pipeline tests.

KronLogger appears too difficult for a unit test: it'd require an InitKron object, which requires in turn more non-trivial objects, a few levels down. It is the current situation for these old classes. Bottom line: we must compare two files: the one produced by the KronLogger with a reference file. TextCheckAndNumbers (this PR)  checks words, integers, and real numbers with the tolerance provided.

Creating a separate class for checking diffs between two files looks bad, but the advantage is we get exactly what's needed without dependencies. Let me know what you think, though.