### PR TITLE
Make test1.cpp use Catch2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,6 +6,7 @@ UseTab: ForIndentation
 TabWidth: 8
 IndentWidth: 8
 BreakBeforeBraces: Custom
+BreakStringLiterals: false
 IndentAccessModifiers: false
 AccessModifierOffset: -8
 EmptyLineAfterAccessModifier: Always

--- a/dmrg/KronUtil/CMakeLists.txt
+++ b/dmrg/KronUtil/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 if(BUILD_TESTING)
   add_executable(KronUtil_Test1 test1.cpp)
-  target_link_libraries(KronUtil_Test1 kronutil)
+  target_link_libraries(KronUtil_Test1 kronutil Catch2::Catch2)
   add_test(NAME KronUtil_Test1 COMMAND KronUtil_Test1)
 
   add_executable(KronUtil_Test2 test2.cpp)

--- a/dmrg/KronUtil/den_gen_matrix.cpp
+++ b/dmrg/KronUtil/den_gen_matrix.cpp
@@ -1,5 +1,7 @@
 #include "util.h"
 
+#include <random>
+
 template <typename ComplexOrRealType>
 void den_gen_matrix(const int                                                 nrow_A,
                     const int                                                 ncol_A,
@@ -18,17 +20,20 @@ void den_gen_matrix(const int                                                 nr
 	using RealType                = typename PsimagLite::Real<ComplexOrRealType>::Type;
 	const ComplexOrRealType dzero = 0;
 
-	int ia = 0;
-	int ja = 0;
+	std::random_device rd;
+	std::mt19937       rng(rd());
 
-	for (ja = 0; ja < ncol_A; ja++) {
-		for (ia = 0; ia < nrow_A; ia++) {
-			RealType drand = rand() / static_cast<RealType>(RAND_MAX);
-			RealType aij   = rand() / static_cast<RealType>(RAND_MAX);
+	std::uniform_real_distribution<RealType> value(-1.0, 1.0);
+	std::uniform_real_distribution<RealType> keep(0.0, 1.0);
 
-			int is_accept = (drand <= threshold);
-
-			a_(ia, ja) = (is_accept) ? aij : dzero;
+	for (int ja = 0; ja < ncol_A; ja++) {
+		for (int ia = 0; ia < nrow_A; ia++) {
+			if constexpr (PsimagLite::IsComplexNumber<ComplexOrRealType>::True)
+				a_(ia, ja) = (keep(rng) <= threshold)
+				    ? ComplexOrRealType(value(rng), value(rng))
+				    : dzero;
+			else
+				a_(ia, ja) = (keep(rng) <= threshold) ? value(rng) : dzero;
 		}
 	}
 }

--- a/dmrg/KronUtil/test1.cpp
+++ b/dmrg/KronUtil/test1.cpp
@@ -401,64 +401,34 @@ template <typename T> void run_kron_checks()
 											if (diffmax
 											    > tol) {
 												INFO(
-												    "den: "
-												    "transA"
-												    "="
+												    "den: transA="
 												    << transA
-												    << ", "
-												       "itr"
-												       "ans"
-												       "A "
+												    << ", itransA "
 												    << itransA
-												    << " tr"
-												       "ans"
-												       "B="
+												    << " transB="
 												    << transB
-												    << ", "
-												       "itr"
-												       "ans"
-												       "B "
+												    << ", itransB "
 												    << itransB
-												    << " nr"
-												       "ow_"
-												       "A "
+												    << " nrow_A "
 												    << nrow_A
-												    << " nc"
-												       "ol_"
-												       "A "
+												    << " ncol_A "
 												    << ncol_A
-												    << " nr"
-												       "ow_"
-												       "B "
+												    << " nrow_B "
 												    << nrow_B
-												    << " nco"
-												       "l_"
-												       "B "
+												    << " ncol_B "
 												    << ncol_B
 												    << '\n'
 												    << "ix "
 												    << ix
-												    << ", "
-												       "jx "
+												    << ", jx "
 												    << jx
-												    << ", "
-												       "dif"
-												       "f12"
-												       " "
+												    << ", diff12 "
 												    << diff12
-												    << ", "
-												       "dif"
-												       "f23"
-												       " "
+												    << ", diff23 "
 												    << diff23
-												    << ", "
-												       "dif"
-												       "f31"
-												       " "
+												    << ", diff31 "
 												    << diff31
-												    << " di"
-												       "ff4"
-												       "1 "
+												    << " diff41 "
 												    << diff41
 												    << '\n');
 												REQUIRE(
@@ -560,57 +530,32 @@ template <typename T> void run_kron_checks()
 											if (diffmax
 											    > tol) {
 												INFO(
-												    "csr: "
-												    "transA"
-												    "="
+												    "csr: transA="
 												    << transA
-												    << ", "
-												       "itr"
-												       "ans"
-												       "A "
+												    << ", itransA "
 												    << itransA
-												    << " tr"
-												       "ans"
-												       "B="
+												    << " transB="
 												    << transB
-												    << ", "
-												       "itr"
-												       "ans"
-												       "B "
+												    << ", itransB "
 												    << itransB
-												    << " nr"
-												       "ow_"
-												       "A "
+												    << " nrow_A "
 												    << nrow_A
-												    << " nc"
-												       "ol_"
-												       "A "
+												    << " ncol_A "
 												    << ncol_A
-												    << " nr"
-												       "ow_"
-												       "B "
+												    << " nrow_B "
 												    << nrow_B
-												    << " nco"
-												       "l_"
-												       "B "
+												    << " ncol_B "
 												    << ncol_B
 												    << '\n'
 												    << "ix "
 												    << ix
-												    << ", "
-												       "jx "
+												    << ", jx "
 												    << jx
-												    << ", "
-												       "dif"
-												       "f1 "
+												    << ", diff1 "
 												    << diff1
-												    << ", "
-												       "dif"
-												       "f2 "
+												    << ", diff2 "
 												    << diff2
-												    << ", "
-												       "dif"
-												       "f3 "
+												    << ", diff3 "
 												    << diff3
 												    << '\n');
 												REQUIRE(
@@ -755,48 +700,28 @@ template <typename T> void run_kron_checks()
 											if (diffmax
 											    > tol) {
 												INFO(
-												    "den_csr: "
-												    "itr"
-												    "ans"
-												    "A "
+												    "den_csr: itransA "
 												    << itransA
-												    << "itr"
-												       "ans"
-												       "B "
+												    << "itransB "
 												    << itransB
-												    << " nr"
-												       "ow_"
-												       "A "
+												    << " nrow_A "
 												    << nrow_A
-												    << " nc"
-												       "ol_"
-												       "A "
+												    << " ncol_A "
 												    << ncol_A
-												    << " nr"
-												       "ow_"
-												       "B "
+												    << " nrow_B "
 												    << nrow_B
-												    << " nco"
-												       "l_"
-												       "B "
+												    << " ncol_B "
 												    << ncol_B
 												    << '\n'
 												    << "ix "
 												    << ix
-												    << ", "
-												       "jx "
+												    << ", jx "
 												    << jx
-												    << ", "
-												       "dif"
-												       "f1 "
+												    << ", diff1 "
 												    << diff1
-												    << ", "
-												       "dif"
-												       "f2 "
+												    << ", diff2 "
 												    << diff2
-												    << ", "
-												       "dif"
-												       "f3 "
+												    << ", diff3 "
 												    << diff3
 												    << '\n');
 												REQUIRE(
@@ -896,48 +821,28 @@ template <typename T> void run_kron_checks()
 											if (diffmax
 											    > tol) {
 												INFO(
-												    "den_csr: "
-												    "itr"
-												    "ans"
-												    "A "
+												    "den_csr: itransA "
 												    << itransA
-												    << "itr"
-												       "ans"
-												       "B "
+												    << "itransB "
 												    << itransB
-												    << " nr"
-												       "ow_"
-												       "A "
+												    << " nrow_A "
 												    << nrow_A
-												    << " nc"
-												       "ol_"
-												       "A "
+												    << " ncol_A "
 												    << ncol_A
-												    << " nr"
-												       "ow_"
-												       "B "
+												    << " nrow_B "
 												    << nrow_B
-												    << " nco"
-												       "l_"
-												       "B "
+												    << " ncol_B "
 												    << ncol_B
 												    << '\n'
 												    << "ix "
 												    << ix
-												    << ", "
-												       "jx "
+												    << ", jx "
 												    << jx
-												    << ", "
-												       "dif"
-												       "f1 "
+												    << ", diff1 "
 												    << diff1
-												    << ", "
-												       "dif"
-												       "f2 "
+												    << ", diff2 "
 												    << diff2
-												    << ", "
-												       "dif"
-												       "f3 "
+												    << ", diff3 "
 												    << diff3
 												    << '\n');
 												REQUIRE(
@@ -999,48 +904,28 @@ template <typename T> void run_kron_checks()
 											if (diffmax
 											    > tol) {
 												INFO(
-												    "den_csr: "
-												    "itr"
-												    "ans"
-												    "A "
+												    "den_csr: itransA "
 												    << itransA
-												    << "itr"
-												       "ans"
-												       "B "
+												    << "itransB "
 												    << itransB
-												    << " nr"
-												       "ow_"
-												       "A "
+												    << " nrow_A "
 												    << nrow_A
-												    << " nc"
-												       "ol_"
-												       "A "
+												    << " ncol_A "
 												    << ncol_A
-												    << " nr"
-												       "ow_"
-												       "B "
+												    << " nrow_B "
 												    << nrow_B
-												    << " nco"
-												       "l_"
-												       "B "
+												    << " ncol_B "
 												    << ncol_B
 												    << '\n'
 												    << "ix "
 												    << ix
-												    << ", "
-												       "jx "
+												    << ", jx "
 												    << jx
-												    << ", "
-												       "dif"
-												       "f1 "
+												    << ", diff1 "
 												    << diff1
-												    << ", "
-												       "dif"
-												       "f2 "
+												    << ", diff2 "
 												    << diff2
-												    << ", "
-												       "dif"
-												       "f3 "
+												    << ", diff3 "
 												    << diff3
 												    << '\n');
 												REQUIRE(
@@ -1135,48 +1020,28 @@ template <typename T> void run_kron_checks()
 											if (diffmax
 											    > tol) {
 												INFO(
-												    "den_csr: "
-												    "itr"
-												    "ans"
-												    "A "
+												    "den_csr: itransA "
 												    << itransA
-												    << "itr"
-												       "ans"
-												       "B "
+												    << "itransB "
 												    << itransB
-												    << " nr"
-												       "ow_"
-												       "A "
+												    << " nrow_A "
 												    << nrow_A
-												    << " nc"
-												       "ol_"
-												       "A "
+												    << " ncol_A "
 												    << ncol_A
-												    << " nr"
-												       "ow_"
-												       "B "
+												    << " nrow_B "
 												    << nrow_B
-												    << " nco"
-												       "l_"
-												       "B "
+												    << " ncol_B "
 												    << ncol_B
 												    << '\n'
 												    << "ix "
 												    << ix
-												    << ", "
-												       "jx "
+												    << ", jx "
 												    << jx
-												    << ", "
-												       "dif"
-												       "f1 "
+												    << ", diff1 "
 												    << diff1
-												    << ", "
-												       "dif"
-												       "f2 "
+												    << ", diff2 "
 												    << diff2
-												    << ", "
-												       "dif"
-												       "f3 "
+												    << ", diff3 "
 												    << diff3
 												    << '\n');
 												REQUIRE(

--- a/dmrg/KronUtil/test1.cpp
+++ b/dmrg/KronUtil/test1.cpp
@@ -10,7 +10,7 @@
 template <typename T> void run_kron_checks()
 {
 	using RealT                   = typename PsimagLite::Real<T>::Type;
-	const RealT denseFlopDiscount = RealT(0.2);
+	const RealT denseFlopDiscount = 0.2;
 	double      thresholdA        = 0.0;
 	double      thresholdB        = 0.0;
 	int         nrow_A            = 0;

--- a/dmrg/KronUtil/test1.cpp
+++ b/dmrg/KronUtil/test1.cpp
@@ -2,33 +2,28 @@
 #include "util.h"
 
 #include <Kokkos_Core.hpp>
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <complex>
 
-#ifndef USE_FLOAT
-using RealType = double;
-#else
-using RealType = float;
-#endif
-
-int main()
+template <typename T> void run_kron_checks()
 {
-	Kokkos::ScopeGuard scope_guard;
+	using RealT                   = typename PsimagLite::Real<T>::Type;
+	const RealT denseFlopDiscount = RealT(0.2);
+	double      thresholdA        = 0.0;
+	double      thresholdB        = 0.0;
+	int         nrow_A            = 0;
+	int         ncol_A            = 0;
+	int         nrow_B            = 0;
+	int         ncol_B            = 0;
+	int         itransA           = 0;
+	int         itransB           = 0;
 
-	const RealType denseFlopDiscount = 0.2;
-	const int      idebug            = 0;
-	int            nerrors           = 0;
-	RealType       thresholdA        = 0;
-	RealType       thresholdB        = 0;
-	int            nrow_A            = 0;
-	int            ncol_A            = 0;
-	int            nrow_B            = 0;
-	int            ncol_B            = 0;
-	int            itransA           = 0;
-	int            itransB           = 0;
-
-	static const bool           needsPrinting   = false;
-	const SizeType              gemmRnb         = 49;
-	const SizeType              threadsForGemmR = 1;
-	PsimagLite::GemmR<RealType> gemmR(needsPrinting, gemmRnb, threadsForGemmR);
+	static const bool    needsPrinting   = false;
+	const SizeType       gemmRnb         = 49;
+	const SizeType       threadsForGemmR = 1;
+	PsimagLite::GemmR<T> gemmR(needsPrinting, gemmRnb, threadsForGemmR);
 
 	for (thresholdB = 0; thresholdB <= 1.1; thresholdB += 0.1) {
 		for (thresholdA = 0; thresholdA <= 1.1; thresholdA += 0.1) {
@@ -94,114 +89,89 @@ int main()
 									int nrow_Y = ncol_2;
 									int ncol_Y = ncol_1;
 
-									PsimagLite::Matrix<RealType>
-									    a_(nrow_A, ncol_A);
-									PsimagLite::Matrix<RealType>
-									    b_(nrow_B, ncol_B);
+									PsimagLite::Matrix<T> a_(
+									    nrow_A, ncol_A);
+									PsimagLite::Matrix<T> b_(
+									    nrow_B, ncol_B);
 
-									PsimagLite::Matrix<RealType>
-									    y_(nrow_Y, ncol_Y);
+									PsimagLite::Matrix<T> y_(
+									    nrow_Y, ncol_Y);
 									PsimagLite::MatrixNonOwned<
-									    const RealType>
+									    const T>
 									    yRef(y_);
 
-									PsimagLite::Matrix<RealType>
-									    x1_(nrow_X, ncol_X);
+									PsimagLite::Matrix<T> x1_(
+									    nrow_X, ncol_X);
 									PsimagLite::MatrixNonOwned<
-									    RealType>
+									    T>
 									    x1Ref(x1_);
-									PsimagLite::Matrix<RealType>
-									    x2_(nrow_X, ncol_X);
+									PsimagLite::Matrix<T> x2_(
+									    nrow_X, ncol_X);
 									PsimagLite::MatrixNonOwned<
-									    RealType>
+									    T>
 									    x2Ref(x2_);
-									PsimagLite::Matrix<RealType>
-									    x3_(nrow_X, ncol_X);
+									PsimagLite::Matrix<T> x3_(
+									    nrow_X, ncol_X);
 									PsimagLite::MatrixNonOwned<
-									    RealType>
+									    T>
 									    x3Ref(x3_);
-									PsimagLite::Matrix<RealType>
-									    x4_(nrow_X, ncol_X);
+									PsimagLite::Matrix<T> x4_(
+									    nrow_X, ncol_X);
 									PsimagLite::MatrixNonOwned<
-									    RealType>
+									    T>
 									    x4Ref(x4_);
 
-									PsimagLite::Matrix<RealType>
-									    sx1_(nrow_X, ncol_X);
+									PsimagLite::Matrix<T> sx1_(
+									    nrow_X, ncol_X);
 									PsimagLite::MatrixNonOwned<
-									    RealType>
+									    T>
 									    sx1Ref(sx1_);
-									PsimagLite::Matrix<RealType>
-									    sx2_(nrow_X, ncol_X);
+									PsimagLite::Matrix<T> sx2_(
+									    nrow_X, ncol_X);
 									PsimagLite::MatrixNonOwned<
-									    RealType>
+									    T>
 									    sx2Ref(sx2_);
-									PsimagLite::Matrix<RealType>
-									    sx3_(nrow_X, ncol_X);
+									PsimagLite::Matrix<T> sx3_(
+									    nrow_X, ncol_X);
 									PsimagLite::MatrixNonOwned<
-									    RealType>
+									    T>
 									    sx3Ref(sx3_);
-									PsimagLite::Matrix<RealType>
-									    sx4_(nrow_X, ncol_X);
+									PsimagLite::Matrix<T> sx4_(
+									    nrow_X, ncol_X);
 									PsimagLite::MatrixNonOwned<
-									    RealType>
+									    T>
 									    sx4Ref(sx4_);
 
 									if (thresholdA == 0) {
 										if (nrow_A
 										    == ncol_A) {
-											/*
-											 * ------------------------------------
-											 * special
-											 * case to
-											 * test
-											 * identity
-											 * matrix
-											 * ------------------------------------
-											 */
-											if (idebug
-											    >= 1) {
-												printf(
-												    "nrow_A=%d, identity \n",
-												    nrow_A);
-											}
 											den_eye(
 											    nrow_A,
 											    ncol_A,
 											    a_);
-											assert(
+											REQUIRE(
 											    den_is_eye(
 											        a_));
-
 											PsimagLite::
 											    CrsMatrix<
-											        RealType>
+											        T>
 											        a(a_);
-											assert(
+											REQUIRE(
 											    csr_is_eye(
 											        a));
 										} else {
-											if (idebug
-											    >= 1) {
-												printf(
-												    "nrow_A=%d,ncol_A=%d, zeros\n",
-												    nrow_A,
-												    ncol_A);
-											}
-
 											den_zeros(
 											    nrow_A,
 											    ncol_A,
 											    a_);
-											assert(
+											REQUIRE(
 											    den_is_zeros(
 											        a_));
-
 											PsimagLite::
 											    CrsMatrix<
-											        RealType>
+											        T>
 											        a(a_);
-											assert(
+											REQUIRE(
 											    csr_is_zeros(
 											        a));
 										}
@@ -211,16 +181,14 @@ int main()
 										    ncol_A,
 										    thresholdA,
 										    a_);
-
 										PsimagLite::
-										    CrsMatrix<
-										        RealType>
+										    CrsMatrix<T>
 										        a(a_);
-										assert(
+										REQUIRE(
 										    den_is_eye(a_)
 										    == csr_is_eye(
 										        a));
-										assert(
+										REQUIRE(
 										    den_is_zeros(a_)
 										    == csr_is_zeros(
 										        a));
@@ -228,32 +196,15 @@ int main()
 
 									if ((thresholdB == 0)
 									    && (nrow_B == ncol_B)) {
-										/*
-										 * ------------------------------------
-										 * special case to
-										 * test identity
-										 * matrix
-										 * ------------------------------------
-										 */
-										if (idebug >= 1) {
-											printf(
-											    "nrow_"
-											    "B=%d, "
-											    "identi"
-											    "ty \n",
-											    nrow_B);
-										}
 										den_eye(nrow_B,
 										        ncol_B,
 										        b_);
-										assert(
+										REQUIRE(
 										    den_is_eye(b_));
-
 										PsimagLite::
-										    CrsMatrix<
-										        RealType>
+										    CrsMatrix<T>
 										        b(b_);
-										assert(
+										REQUIRE(
 										    csr_is_eye(b));
 									} else {
 										den_gen_matrix(
@@ -261,16 +212,14 @@ int main()
 										    ncol_B,
 										    thresholdB,
 										    b_);
-
 										PsimagLite::
-										    CrsMatrix<
-										        RealType>
+										    CrsMatrix<T>
 										        b(b_);
-										assert(
+										REQUIRE(
 										    den_is_eye(b_)
 										    == csr_is_eye(
 										        b));
-										assert(
+										REQUIRE(
 										    den_is_zeros(b_)
 										    == csr_is_zeros(
 										        b));
@@ -336,8 +285,8 @@ int main()
 									// ------------------
 									// form C = kron(A,B)
 									// ------------------
-									PsimagLite::Matrix<RealType>
-									    c_(nrow_C, ncol_C);
+									PsimagLite::Matrix<T> c_(
+									    nrow_C, ncol_C);
 
 									den_kron_form_general(
 									    transA,
@@ -358,10 +307,8 @@ int main()
 										    = 'N';
 										const char trans2
 										    = 'N';
-										const RealType alpha
-										    = 1.0;
-										const RealType beta
-										    = 0.0;
+										const T alpha = 1.0;
+										const T beta  = 0.0;
 
 										// ------------------------------
 										// reshape X, Y as
@@ -383,14 +330,12 @@ int main()
 										    = nrow_X
 										    * ncol_X;
 
-										const RealType* const
-										    pA
+										const T* const pA
 										    = &(c_(0, 0));
-										const RealType* const
-										    pB
-										    = &(yRef.getVector()
-										            [0]);
-										RealType* pC = &(
+										const T* const pB = &(
+										    yRef.getVector()
+										        [0]);
+										T* pC = &(
 										    x4Ref
 										        .getVector()
 										            [0]);
@@ -410,84 +355,115 @@ int main()
 										    ld3);
 									}
 
-									int ix = 0;
-									int jx = 0;
-
-									for (jx = 0; jx < ncol_X;
-									     jx++) {
-										for (ix = 0;
+									for (int jx = 0;
+									     jx < ncol_X;
+									     ++jx) {
+										for (int ix = 0;
 										     ix < nrow_X;
-										     ix++) {
-											RealType
-											    diff12
-											    = std::abs(
-											        x1_(ix,
-											            jx)
-											        - x2_(
-											            ix,
-											            jx));
-											RealType
-											    diff23
-											    = std::abs(
-											        x2_(ix,
-											            jx)
-											        - x3_(
-											            ix,
-											            jx));
-											RealType
-											    diff31
-											    = std::abs(
-											        x3_(ix,
-											            jx)
-											        - x1_(
-											            ix,
-											            jx));
-											RealType
-											    diff41
-											    = std::abs(
-											        x4_(ix,
-											            jx)
-											        - x1_(
-											            ix,
-											            jx));
-											RealType diffmax = std::max(
+										     ++ix) {
+											auto diff12 = std::abs(
+											    x1_(ix,
+											        jx)
+											    - x2_(
+											        ix,
+											        jx));
+											auto diff23 = std::abs(
+											    x2_(ix,
+											        jx)
+											    - x3_(
+											        ix,
+											        jx));
+											auto diff31 = std::abs(
+											    x3_(ix,
+											        jx)
+											    - x1_(
+											        ix,
+											        jx));
+											auto diff41 = std::abs(
+											    x4_(ix,
+											        jx)
+											    - x1_(
+											        ix,
+											        jx));
+											auto diffmax = std::max(
 											    diff41,
 											    std::max(
 											        diff12,
 											        std::max(
 											            diff23,
 											            diff31)));
-											const RealType
+											const double
 											    tol
 											    = 1.0
 											    / (1000.0
 											       * 1000.0
 											       * 1000.0);
-
-											int isok
-											    = (diffmax
-											       <= tol);
-											if (!isok) {
-												nerrors
-												    += 1;
-												printf(
-												    "den: transA=%c, itransA %d transB=%c, itransB %d nrow_A %d ncol_A %d nrow_B %d ncol_B %d \n",
-												    transA,
-												    itransA,
-												    transB,
-												    itransB,
-												    nrow_A,
-												    ncol_A,
-												    nrow_B,
-												    ncol_B);
-												printf(
-												    "ix %d, jx %d, diff12 %f, diff23 %f, diff31 %f diff41 %f \n",
-												    ix,
-												    jx,
-												    diff12,
-												    diff23,
-												    diff31,
-												    diff41);
+											if (diffmax
+											    > tol) {
+												INFO(
+												    "den: "
+												    "transA"
+												    "="
+												    << transA
+												    << ", "
+												       "itr"
+												       "ans"
+												       "A "
+												    << itransA
+												    << " tr"
+												       "ans"
+												       "B="
+												    << transB
+												    << ", "
+												       "itr"
+												       "ans"
+												       "B "
+												    << itransB
+												    << " nr"
+												       "ow_"
+												       "A "
+												    << nrow_A
+												    << " nc"
+												       "ol_"
+												       "A "
+												    << ncol_A
+												    << " nr"
+												       "ow_"
+												       "B "
+												    << nrow_B
+												    << " nco"
+												       "l_"
+												       "B "
+												    << ncol_B
+												    << '\n'
+												    << "ix "
+												    << ix
+												    << ", "
+												       "jx "
+												    << jx
+												    << ", "
+												       "dif"
+												       "f12"
+												       " "
+												    << diff12
+												    << ", "
+												       "dif"
+												       "f23"
+												       " "
+												    << diff23
+												    << ", "
+												       "dif"
+												       "f31"
+												       " "
+												    << diff31
+												    << " di"
+												       "ff4"
+												       "1 "
+												    << diff41
+												    << '\n');
+												REQUIRE(
+												    diffmax
+												    <= tol);
 											}
 										}
 									}
@@ -497,21 +473,18 @@ int main()
 									 * test sparse matrix
 									 * ------------------
 									 */
-									PsimagLite::CrsMatrix<
-									    RealType>
-									    a(a_);
-									assert(den_is_eye(a_)
-									       == csr_is_eye(a));
-									assert(den_is_zeros(a_)
-									       == csr_is_zeros(a));
-
-									PsimagLite::CrsMatrix<
-									    RealType>
-									    b(b_);
-									assert(den_is_eye(b_)
-									       == csr_is_eye(b));
-									assert(den_is_zeros(b_)
-									       == csr_is_zeros(b));
+									PsimagLite::CrsMatrix<T> a(
+									    a_);
+									REQUIRE(den_is_eye(a_)
+									        == csr_is_eye(a));
+									REQUIRE(den_is_zeros(a_)
+									        == csr_is_zeros(a));
+									PsimagLite::CrsMatrix<T> b(
+									    b_);
+									REQUIRE(den_is_eye(b_)
+									        == csr_is_eye(b));
+									REQUIRE(den_is_zeros(b_)
+									        == csr_is_zeros(b));
 
 									imethod = 1;
 									csr_kron_mult_method(
@@ -549,69 +522,100 @@ int main()
 									    yRef,
 									    sx3Ref);
 
-									for (jx = 0; jx < ncol_X;
-									     jx++) {
-										for (ix = 0;
+									for (int jx = 0;
+									     jx < ncol_X;
+									     ++jx) {
+										for (int ix = 0;
 										     ix < nrow_X;
-										     ix++) {
-											RealType
-											    diff1
-											    = std::abs(
-											        x1_(ix,
-											            jx)
-											        - sx1_(
-											            ix,
-											            jx));
-											RealType
-											    diff2
-											    = std::abs(
-											        x2_(ix,
-											            jx)
-											        - sx2_(
-											            ix,
-											            jx));
-											RealType
-											    diff3
-											    = std::abs(
-											        x3_(ix,
-											            jx)
-											        - sx3_(
-											            ix,
-											            jx));
-											RealType
-											    diffmax
-											    = std::max(
-											        diff1,
-											        std::max(
-											            diff2,
-											            diff3));
-											const RealType
+										     ++ix) {
+											auto diff1 = std::abs(
+											    x1_(ix,
+											        jx)
+											    - sx1_(
+											        ix,
+											        jx));
+											auto diff2 = std::abs(
+											    x2_(ix,
+											        jx)
+											    - sx2_(
+											        ix,
+											        jx));
+											auto diff3 = std::abs(
+											    x3_(ix,
+											        jx)
+											    - sx3_(
+											        ix,
+											        jx));
+											auto diffmax = std::max(
+											    diff1,
+											    std::max(
+											        diff2,
+											        diff3));
+											const double
 											    tol
 											    = 1.0
 											    / (1000.0
 											       * 1000.0
 											       * 1000.0);
-											int isok
-											    = (diffmax
-											       <= tol);
-											if (!isok) {
-												nerrors
-												    += 1;
-												printf(
-												    "csr: itransA %d itransB %d nrow_A %d ncol_A %d nrow_B %d ncol_B %d \n",
-												    itransA,
-												    itransB,
-												    nrow_A,
-												    ncol_A,
-												    nrow_B,
-												    ncol_B);
-												printf(
-												    "ix %d, jx %d, diff1 %f, diff2 %f, diff3 %f \n",
-												    ix,
-												    jx,
-												    diff1,
-												    diff2,
-												    diff3);
+											if (diffmax
+											    > tol) {
+												INFO(
+												    "csr: "
+												    "transA"
+												    "="
+												    << transA
+												    << ", "
+												       "itr"
+												       "ans"
+												       "A "
+												    << itransA
+												    << " tr"
+												       "ans"
+												       "B="
+												    << transB
+												    << ", "
+												       "itr"
+												       "ans"
+												       "B "
+												    << itransB
+												    << " nr"
+												       "ow_"
+												       "A "
+												    << nrow_A
+												    << " nc"
+												       "ol_"
+												       "A "
+												    << ncol_A
+												    << " nr"
+												       "ow_"
+												       "B "
+												    << nrow_B
+												    << " nco"
+												       "l_"
+												       "B "
+												    << ncol_B
+												    << '\n'
+												    << "ix "
+												    << ix
+												    << ", "
+												       "jx "
+												    << jx
+												    << ", "
+												       "dif"
+												       "f1 "
+												    << diff1
+												    << ", "
+												       "dif"
+												       "f2 "
+												    << diff2
+												    << ", "
+												       "dif"
+												       "f3 "
+												    << diff3
+												    << '\n');
+												REQUIRE(
+												    diffmax
+												    <= tol);
 											}
 										}
 									}
@@ -648,45 +652,49 @@ int main()
 									    0,
 									    sx1Ref.getVector(),
 									    0,
-									    denseFlopDiscount);
+									    RealT(
+									        denseFlopDiscount));
 
-									for (jx = 0; jx < ncol_X;
-									     jx++) {
-										for (ix = 0;
+									for (int jx = 0;
+									     jx < ncol_X;
+									     ++jx) {
+										for (int ix = 0;
 										     ix < nrow_X;
-										     ix++) {
-											RealType
-											    diff
-											    = std::abs(
-											        x1_(ix,
-											            jx)
-											        - sx1_(
-											            ix,
-											            jx));
-											const RealType
+										     ++ix) {
+											auto diff = std::abs(
+											    x1_(ix,
+											        jx)
+											    - sx1_(
+											        ix,
+											        jx));
+											const double
 											    tol
 											    = 1.0
 											    / (1000.0
 											       * 1000.0
 											       * 1000.0);
-
-											int isok
-											    = (diff
-											       <= tol);
-											if (!isok) {
-												nerrors
-												    += 1;
-												printf(
-												    "nrow_A %d ncol_A %d nrow_B %d ncol_B %d \n",
-												    nrow_A,
-												    ncol_A,
-												    nrow_B,
-												    ncol_B);
-												printf(
-												    "ix %d, jx %d, diff %f \n",
-												    ix,
-												    jx,
-												    diff);
+											if (diff
+											    > tol) {
+												INFO(
+												    "nrow_A "
+												    << nrow_A
+												    << " ncol_A "
+												    << ncol_A
+												    << " nrow_B "
+												    << nrow_B
+												    << " ncol_B "
+												    << ncol_B
+												    << '\n'
+												    << "ix "
+												    << ix
+												    << ", jx "
+												    << jx
+												    << ", diff "
+												    << diff
+												    << '\n');
+												REQUIRE(
+												    diff
+												    <= tol);
 											}
 										}
 									}
@@ -713,62 +721,87 @@ int main()
 									    0,
 									    sx1Ref.getVector(),
 									    0,
-									    denseFlopDiscount,
+									    RealT(
+									        denseFlopDiscount),
 									    gemmR);
 
-									for (jx = 0; jx < ncol_X;
-									     jx++) {
-										for (ix = 0;
+									for (int jx = 0;
+									     jx < ncol_X;
+									     ++jx) {
+										for (int ix = 0;
 										     ix < nrow_X;
-										     ix++) {
-											RealType
-											    diff1
-											    = std::abs(
-											        x1_(ix,
-											            jx)
-											        - sx1_(
-											            ix,
-											            jx));
-											RealType
-											    diff2
-											    = 0;
-											RealType
-											    diff3
-											    = 0;
-											RealType
-											    diffmax
-											    = std::max(
-											        diff1,
-											        std::max(
-											            diff2,
-											            diff3));
-											const RealType
+										     ++ix) {
+											auto diff1 = std::abs(
+											    x1_(ix,
+											        jx)
+											    - sx1_(
+											        ix,
+											        jx));
+											auto diff2
+											    = 0.0;
+											auto diff3
+											    = 0.0;
+											auto diffmax = std::max(
+											    diff1,
+											    std::max(
+											        diff2,
+											        diff3));
+											const double
 											    tol
 											    = 1.0
 											    / (1000.0
 											       * 1000.0
 											       * 1000.0);
-											int isok
-											    = (diffmax
-											       <= tol);
-											if (!isok) {
-												nerrors
-												    += 1;
-												printf(
-												    "den_csr: itransA %d itransB %d nrow_A %d ncol_A %d nrow_B %d ncol_B %d \n",
-												    itransA,
-												    itransB,
-												    nrow_A,
-												    ncol_A,
-												    nrow_B,
-												    ncol_B);
-												printf(
-												    "ix %d, jx %d, diff1 %f, diff2 %f, diff3 %f \n",
-												    ix,
-												    jx,
-												    diff1,
-												    diff2,
-												    diff3);
+											if (diffmax
+											    > tol) {
+												INFO(
+												    "den_csr: "
+												    "itr"
+												    "ans"
+												    "A "
+												    << itransA
+												    << "itr"
+												       "ans"
+												       "B "
+												    << itransB
+												    << " nr"
+												       "ow_"
+												       "A "
+												    << nrow_A
+												    << " nc"
+												       "ol_"
+												       "A "
+												    << ncol_A
+												    << " nr"
+												       "ow_"
+												       "B "
+												    << nrow_B
+												    << " nco"
+												       "l_"
+												       "B "
+												    << ncol_B
+												    << '\n'
+												    << "ix "
+												    << ix
+												    << ", "
+												       "jx "
+												    << jx
+												    << ", "
+												       "dif"
+												       "f1 "
+												    << diff1
+												    << ", "
+												       "dif"
+												       "f2 "
+												    << diff2
+												    << ", "
+												       "dif"
+												       "f3 "
+												    << diff3
+												    << '\n');
+												REQUIRE(
+												    diffmax
+												    <= tol);
 											}
 										}
 									}
@@ -825,69 +858,91 @@ int main()
 									    0,
 									    gemmR);
 
-									for (jx = 0; jx < ncol_X;
-									     jx++) {
-										for (ix = 0;
+									for (int jx = 0;
+									     jx < ncol_X;
+									     ++jx) {
+										for (int ix = 0;
 										     ix < nrow_X;
-										     ix++) {
-											RealType
-											    diff1
-											    = std::abs(
-											        x1_(ix,
-											            jx)
-											        - sx1_(
-											            ix,
-											            jx));
-											RealType
-											    diff2
-											    = std::abs(
-											        x2_(ix,
-											            jx)
-											        - sx2_(
-											            ix,
-											            jx));
-											RealType
-											    diff3
-											    = std::abs(
-											        x3_(ix,
-											            jx)
-											        - sx3_(
-											            ix,
-											            jx));
-											RealType
-											    diffmax
-											    = std::max(
-											        diff1,
-											        std::max(
-											            diff2,
-											            diff3));
-											const RealType
+										     ++ix) {
+											auto diff1 = std::abs(
+											    x1_(ix,
+											        jx)
+											    - sx1_(
+											        ix,
+											        jx));
+											auto diff2 = std::abs(
+											    x2_(ix,
+											        jx)
+											    - sx2_(
+											        ix,
+											        jx));
+											auto diff3 = std::abs(
+											    x3_(ix,
+											        jx)
+											    - sx3_(
+											        ix,
+											        jx));
+											auto diffmax = std::max(
+											    diff1,
+											    std::max(
+											        diff2,
+											        diff3));
+											const double
 											    tol
 											    = 1.0
 											    / (1000.0
 											       * 1000.0
 											       * 1000.0);
-											int isok
-											    = (diffmax
-											       <= tol);
-											if (!isok) {
-												nerrors
-												    += 1;
-												printf(
-												    "den_csr: itransA %d itransB %d nrow_A %d ncol_A %d nrow_B %d ncol_B %d \n",
-												    itransA,
-												    itransB,
-												    nrow_A,
-												    ncol_A,
-												    nrow_B,
-												    ncol_B);
-												printf(
-												    "ix %d, jx %d, diff1 %f, diff2 %f, diff3 %f \n",
-												    ix,
-												    jx,
-												    diff1,
-												    diff2,
-												    diff3);
+											if (diffmax
+											    > tol) {
+												INFO(
+												    "den_csr: "
+												    "itr"
+												    "ans"
+												    "A "
+												    << itransA
+												    << "itr"
+												       "ans"
+												       "B "
+												    << itransB
+												    << " nr"
+												       "ow_"
+												       "A "
+												    << nrow_A
+												    << " nc"
+												       "ol_"
+												       "A "
+												    << ncol_A
+												    << " nr"
+												       "ow_"
+												       "B "
+												    << nrow_B
+												    << " nco"
+												       "l_"
+												       "B "
+												    << ncol_B
+												    << '\n'
+												    << "ix "
+												    << ix
+												    << ", "
+												       "jx "
+												    << jx
+												    << ", "
+												       "dif"
+												       "f1 "
+												    << diff1
+												    << ", "
+												       "dif"
+												       "f2 "
+												    << diff2
+												    << ", "
+												       "dif"
+												       "f3 "
+												    << diff3
+												    << '\n');
+												REQUIRE(
+												    diffmax
+												    <= tol);
 											}
 										}
 									}
@@ -910,62 +965,87 @@ int main()
 									    0,
 									    sx1Ref.getVector(),
 									    0,
-									    denseFlopDiscount,
+									    RealT(
+									        denseFlopDiscount),
 									    gemmR);
 
-									for (jx = 0; jx < ncol_X;
-									     jx++) {
-										for (ix = 0;
+									for (int jx = 0;
+									     jx < ncol_X;
+									     ++jx) {
+										for (int ix = 0;
 										     ix < nrow_X;
-										     ix++) {
-											RealType
-											    diff1
-											    = std::abs(
-											        x1_(ix,
-											            jx)
-											        - sx1_(
-											            ix,
-											            jx));
-											RealType
-											    diff2
-											    = 0;
-											RealType
-											    diff3
-											    = 0;
-											RealType
-											    diffmax
-											    = std::max(
-											        diff1,
-											        std::max(
-											            diff2,
-											            diff3));
-											const RealType
+										     ++ix) {
+											auto diff1 = std::abs(
+											    x1_(ix,
+											        jx)
+											    - sx1_(
+											        ix,
+											        jx));
+											auto diff2
+											    = 0.0;
+											auto diff3
+											    = 0.0;
+											auto diffmax = std::max(
+											    diff1,
+											    std::max(
+											        diff2,
+											        diff3));
+											const double
 											    tol
 											    = 1.0
 											    / (1000.0
 											       * 1000.0
 											       * 1000.0);
-											int isok
-											    = (diffmax
-											       <= tol);
-											if (!isok) {
-												nerrors
-												    += 1;
-												printf(
-												    "den_csr: itransA %d itransB %d nrow_A %d ncol_A %d nrow_B %d ncol_B %d \n",
-												    itransA,
-												    itransB,
-												    nrow_A,
-												    ncol_A,
-												    nrow_B,
-												    ncol_B);
-												printf(
-												    "ix %d, jx %d, diff1 %f, diff2 %f, diff3 %f \n",
-												    ix,
-												    jx,
-												    diff1,
-												    diff2,
-												    diff3);
+											if (diffmax
+											    > tol) {
+												INFO(
+												    "den_csr: "
+												    "itr"
+												    "ans"
+												    "A "
+												    << itransA
+												    << "itr"
+												       "ans"
+												       "B "
+												    << itransB
+												    << " nr"
+												       "ow_"
+												       "A "
+												    << nrow_A
+												    << " nc"
+												       "ol_"
+												       "A "
+												    << ncol_A
+												    << " nr"
+												       "ow_"
+												       "B "
+												    << nrow_B
+												    << " nco"
+												       "l_"
+												       "B "
+												    << ncol_B
+												    << '\n'
+												    << "ix "
+												    << ix
+												    << ", "
+												       "jx "
+												    << jx
+												    << ", "
+												       "dif"
+												       "f1 "
+												    << diff1
+												    << ", "
+												       "dif"
+												       "f2 "
+												    << diff2
+												    << ", "
+												       "dif"
+												       "f3 "
+												    << diff3
+												    << '\n');
+												REQUIRE(
+												    diffmax
+												    <= tol);
 											}
 										}
 									}
@@ -1017,69 +1097,91 @@ int main()
 									    izero,
 									    gemmR);
 
-									for (jx = 0; jx < ncol_X;
-									     jx++) {
-										for (ix = 0;
+									for (int jx = 0;
+									     jx < ncol_X;
+									     ++jx) {
+										for (int ix = 0;
 										     ix < nrow_X;
-										     ix++) {
-											RealType
-											    diff1
-											    = std::abs(
-											        x1_(ix,
-											            jx)
-											        - sx1_(
-											            ix,
-											            jx));
-											RealType
-											    diff2
-											    = std::abs(
-											        x2_(ix,
-											            jx)
-											        - sx2_(
-											            ix,
-											            jx));
-											RealType
-											    diff3
-											    = std::abs(
-											        x3_(ix,
-											            jx)
-											        - sx3_(
-											            ix,
-											            jx));
-											RealType
-											    diffmax
-											    = std::max(
-											        diff1,
-											        std::max(
-											            diff2,
-											            diff3));
-											const RealType
+										     ++ix) {
+											auto diff1 = std::abs(
+											    x1_(ix,
+											        jx)
+											    - sx1_(
+											        ix,
+											        jx));
+											auto diff2 = std::abs(
+											    x2_(ix,
+											        jx)
+											    - sx2_(
+											        ix,
+											        jx));
+											auto diff3 = std::abs(
+											    x3_(ix,
+											        jx)
+											    - sx3_(
+											        ix,
+											        jx));
+											auto diffmax = std::max(
+											    diff1,
+											    std::max(
+											        diff2,
+											        diff3));
+											const double
 											    tol
 											    = 1.0
 											    / (1000.0
 											       * 1000.0
 											       * 1000.0);
-											int isok
-											    = (diffmax
-											       <= tol);
-											if (!isok) {
-												nerrors
-												    += 1;
-												printf(
-												    "den_csr: itransA %d itransB %d nrow_A %d ncol_A %d nrow_B %d ncol_B %d \n",
-												    itransA,
-												    itransB,
-												    nrow_A,
-												    ncol_A,
-												    nrow_B,
-												    ncol_B);
-												printf(
-												    "ix %d, jx %d, diff1 %f, diff2 %f, diff3 %f \n",
-												    ix,
-												    jx,
-												    diff1,
-												    diff2,
-												    diff3);
+											if (diffmax
+											    > tol) {
+												INFO(
+												    "den_csr: "
+												    "itr"
+												    "ans"
+												    "A "
+												    << itransA
+												    << "itr"
+												       "ans"
+												       "B "
+												    << itransB
+												    << " nr"
+												       "ow_"
+												       "A "
+												    << nrow_A
+												    << " nc"
+												       "ol_"
+												       "A "
+												    << ncol_A
+												    << " nr"
+												       "ow_"
+												       "B "
+												    << nrow_B
+												    << " nco"
+												       "l_"
+												       "B "
+												    << ncol_B
+												    << '\n'
+												    << "ix "
+												    << ix
+												    << ", "
+												       "jx "
+												    << jx
+												    << ", "
+												       "dif"
+												       "f1 "
+												    << diff1
+												    << ", "
+												       "dif"
+												       "f2 "
+												    << diff2
+												    << ", "
+												       "dif"
+												       "f3 "
+												    << diff3
+												    << '\n');
+												REQUIRE(
+												    diffmax
+												    <= tol);
 											}
 										}
 									}
@@ -1091,19 +1193,16 @@ int main()
 			}
 		}
 	}
-
-	if (nerrors == 0) {
-		printf("pass all tests\n");
-	}
-	return (0);
 }
 
-#undef X1
-#undef X2
-#undef X3
-#undef SX1
-#undef SX2
-#undef SX3
-#undef A
-#undef B
-#undef Y
+TEST_CASE("kron_mult_test1_double", "[kron][basic]") { run_kron_checks<double>(); }
+
+TEST_CASE("kron_mult_test1_complex", "[kron][basic]") { run_kron_checks<std::complex<double>>(); }
+
+int main(int argc, char* argv[])
+{
+	Kokkos::initialize(argc, argv);
+	int result = Catch::Session().run(argc, argv);
+	Kokkos::finalize();
+	return result;
+}


### PR DESCRIPTION
Wr noticed in https://github.com/dmrgpp-project/dmrgpp/pull/229#issuecomment-5074141356 that we do have tests for `csr_kron_mult` and `den_kron_mult` but it neither uses `Catch2`, nor errors out on failure or tests with `std::complex`. This pull request fixes that.
Sample output when making `imethod=3` a no-op:
```
Randomness seeded to: 2133787757

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
KronUtil_Test1 is a Catch2 v3.11.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
kron_mult_test1_double
-------------------------------------------------------------------------------
/tmp/dmrgpp/dmrg/KronUtil/test1.cpp:1198
...............................................................................

/tmp/dmrgpp/dmrg/KronUtil/test1.cpp:618: FAILED:
  REQUIRE( diffmax <= tol )
with expansion:
  0.20663306635186229 <= 0.000000001
with message:
  csr: transA=N, itransA 0 transB=N, itransB 0 nrow_A 1 ncol_A 1 nrow_B 1
  ncol_B 1
  ix 0, jx 0, diff1 0, diff2 0, diff3 0.206633

-------------------------------------------------------------------------------
kron_mult_test1_complex
-------------------------------------------------------------------------------
/tmp/dmrgpp/dmrg/KronUtil/test1.cpp:1200
...............................................................................

/tmp/dmrgpp/dmrg/KronUtil/test1.cpp:618: FAILED:
  REQUIRE( diffmax <= tol )
with expansion:
  0.3228655156206291 <= 0.000000001
with message:
  csr: transA=N, itransA 0 transB=N, itransB 0 nrow_A 1 ncol_A 1 nrow_B 1
  ncol_B 1
  ix 0, jx 0, diff1 0, diff2 0, diff3 0.322866

===============================================================================
test cases:  2 |  0 passed | 2 failed
assertions: 18 | 16 passed | 2 failed
```
