### PR TITLE
Introduce DMRG_BATCHED_GEMM_TYPE as CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,16 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   add_compile_options(-Wall -Wextra -Wno-unused-parameter)
 endif()
 
-option(DMRG_BUILD_BATCHED "Enable building with Batched support" ON)
+if(NOT DMRG_BATCHED_GEMM_TYPE)
+  set(DMRG_BATCHED_GEMM_TYPE
+      "Plugin"
+      CACHE STRING "Choose the batched gemm implementation" FORCE)
+  set_property(CACHE DMRG_BATCHED_GEMM_TYPE PROPERTY STRINGS "CPU" "Plugin")
+endif()
 
 include(CMakeDependentOption)
-cmake_dependent_option(DMRG_BUILD_BATCHED_MAGMA "Enable building with Magma" OFF "DMRG_BUILD_BATCHED" OFF)
+cmake_dependent_option(DMRG_BUILD_BATCHED_MAGMA "Enable building with Magma" OFF
+                       "DMRG_BATCHED_GEMM_TYPE STREQUAL \"Plugin\"" OFF)
 
 add_subdirectory(util)
 

--- a/dmrg/CMakeLists.txt
+++ b/dmrg/CMakeLists.txt
@@ -25,14 +25,14 @@ add_library(dmrgpp_utils ProgramGlobals.cpp Provenance.cpp Utils.cpp Su2Related.
 target_sources(dmrgpp_utils PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/GitRevision.h)
 target_include_directories(dmrgpp_utils PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/GPUPlugin Engine)
 target_link_libraries(dmrgpp_utils PUBLIC psimaglite::psimaglite)
-if(DMRG_BUILD_BATCHED)
+if(DMRG_BATCHED_GEMM_TYPE STREQUAL "Plugin")
   target_link_libraries(dmrgpp_utils PUBLIC gpuplugin)
 endif()
 
 # DMRG runner
 add_library(dmrg_runner Engine/DmrgRunner.cpp)
 target_link_libraries(dmrg_runner PUBLIC dmrgpp_utils kronutil)
-if(DMRG_BUILD_BATCHED)
+if(DMRG_BATCHED_GEMM_TYPE STREQUAL "Plugin")
   target_link_libraries(dmrg_runner PUBLIC gpuplugin)
 endif()
 
@@ -102,10 +102,8 @@ endfunction()
 add_test(NAME input2 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input2.ain)
 add_lowest_eigenvalue_check_test(output2 input2 -9.51754 runForinput2.cout)
 
-if(DMRG_BUILD_BATCHED)
-  add_test(NAME input2_batchedgemm COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input2_batchedgemm.ain)
-  add_lowest_eigenvalue_check_test(output2_batchedgemm input2_batched_gemm -9.51754 runForinput2.cout)
-endif()
+add_test(NAME input2_batchedgemm COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input2_batchedgemm.ain)
+add_lowest_eigenvalue_check_test(output2_batchedgemm input2_batched_gemm -9.51754 runForinput2.cout)
 
 add_test(NAME input3 COMMAND ./dmrg -f ${PATH_TO_INPUTS}/input3.ain) # energy -21.5102
 add_lowest_eigenvalue_check_test(output3 input3 -21.5102 runForinput3.cout)

--- a/dmrg/CMakeLists.txt
+++ b/dmrg/CMakeLists.txt
@@ -5,7 +5,7 @@ add_custom_command(
   COMMENT "Generating Git Revision File"
   VERBATIM)
 
-if(DMRG_BUILD_BATCHED)
+if(DMRG_BATCHED_GEMM_TYPE STREQUAL "Plugin")
   add_subdirectory(GPUPlugin)
   set(PLUGIN_SC ON)
   set(FpType "double")


### PR DESCRIPTION
Since we have multiple valid batched gemm implementations, we should expose some way to choose between them.