### PR TITLE
Force KokkosKernels_ENABLE_TPL_BLAS/LAPACK

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -29,9 +29,7 @@ jobs:
               -B ${{github.workspace}}/build \
               -GNinja \
               -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-              -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
-              -DKokkosKernels_ENABLE_TPL_BLAS=ON \
-              -DKokkosKernels_ENABLE_TPL_LAPACK=ON
+              -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/PsimagLite/src/CMakeLists.txt
+++ b/PsimagLite/src/CMakeLists.txt
@@ -34,8 +34,6 @@ FetchContent_Declare(
   GIT_TAG 5.2.0
   SYSTEM FIND_PACKAGE_ARGS 5.1 NAMES KokkosKernels)
 # Since DRMGPP requires BLAS and LAPACK, we should also make sure KokkosKernels uses these as TPLs
-# FIXME Up to version 5.2 KokkosKernels doesn't export the enabled TPLs in CMake
-#       so we can't check for an externally installed KokkosKernels library
 set(KokkosKernels_ENABLE_TPL_BLAS
     ON
     CACHE BOOL "Whether to enable the BLAS TPL" FORCE)
@@ -43,6 +41,19 @@ set(KokkosKernels_ENABLE_TPL_LAPACK
     ON
     CACHE BOOL "Whether to enable the LAPACK TPL" FORCE)
 FetchContent_MakeAvailable(KokkosKernels)
+if(NOT KokkosKernels_POPULATED)
+  unset(KokkosKernels_ENABLE_TPL_BLAS CACHE)
+  unset(KokkosKernels_ENABLE_TPL_LAPACK CACHE)
+  # Past version 5.2, KokkosKernels exports its TPLs as non-CACHE variables
+  if(KokkosKernels_VERSION VERSION_GREATER_EQUAL 5.2.99)
+    if(NOT KokkosKernels_ENABLE_TPL_BLAS)
+      message(FATAL_ERROR "KokkosKernels must be configured with BLAS support!")
+    endif()
+    if(NOT KokkosKernels_ENABLE_TPL_LAPACK)
+      message(FATAL_ERROR "KokkosKernels must be configured with LAPACK support!")
+    endif()
+  endif()
+endif()
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 
 target_link_libraries(psimaglite PUBLIC Kokkos::kokkoskernels Kokkos::kokkos)

--- a/PsimagLite/src/CMakeLists.txt
+++ b/PsimagLite/src/CMakeLists.txt
@@ -33,6 +33,15 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/kokkos/kokkos-kernels
   GIT_TAG 5.2.0
   SYSTEM FIND_PACKAGE_ARGS 5.1 NAMES KokkosKernels)
+# Since DRMGPP requires BLAS and LAPACK, we should also make sure KokkosKernels uses these as TPLs
+# FIXME Up to version 5.2 KokkosKernels doesn't export the enabled TPLs in CMake
+#       so we can't check for an externally installed KokkosKernels library
+set(KokkosKernels_ENABLE_TPL_BLAS
+    ON
+    CACHE BOOL "Whether to enable the BLAS TPL" FORCE)
+set(KokkosKernels_ENABLE_TPL_LAPACK
+    ON
+    CACHE BOOL "Whether to enable the LAPACK TPL" FORCE)
 FetchContent_MakeAvailable(KokkosKernels)
 list(POP_BACK CMAKE_MESSAGE_INDENT)
 


### PR DESCRIPTION
As dicussed in Teams, it's easy for users to miss selecting a suitable TPL for BLAS and LAPACK in KokkosKernels. This pull request forces those two as TPLs when an external KokkosKernels installation couldn't be found. For an external KokkosKernels installation, the TPLs aren't yet exported at configuration but https://github.com/kokkos/kokkos-kernels/pull/3248 is supposed to fix that.